### PR TITLE
Supporting externally managed Cortex Config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 charts
 .tgz
+cortex

--- a/Chart.lock
+++ b/Chart.lock
@@ -8,8 +8,5 @@ dependencies:
 - name: memcached
   repository: https://kubernetes-charts.storage.googleapis.com/
   version: 3.2.3
-- name: postgresql
-  repository: https://charts.bitnami.com/bitnami
-  version: 8.6.13
-digest: sha256:1a40fe2aae73dfcc54eeb47bad91111c91bcb0eeec9b9dd24e5e0bd2e54a3d9c
-generated: "2020-04-04T20:29:40.131333Z"
+digest: sha256:15343a3a535fa858a532546a47dbb63e1379be1d4081f55b01de56db3d2b7617
+generated: "2020-07-02T10:49:04.929498-07:00"

--- a/templates/alertmanager-dep.yaml
+++ b/templates/alertmanager-dep.yaml
@@ -28,7 +28,9 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
       annotations:
+{{- if not .Values.useExternalConfig }}      
         checksum/config: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+{{- end}}        
         {{- with .Values.alertmanager.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/templates/alertmanager-dep.yaml
+++ b/templates/alertmanager-dep.yaml
@@ -28,7 +28,9 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
       annotations:
-{{- if not .Values.useExternalConfig }}      
+{{- if .Values.useExternalConfig }}      
+        checksum/config: {{ .Values.externalConfigVersion }}
+{{- else }}
         checksum/config: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
 {{- end}}        
         {{- with .Values.alertmanager.podAnnotations }}

--- a/templates/alertmanager-dep.yaml
+++ b/templates/alertmanager-dep.yaml
@@ -96,7 +96,11 @@ spec:
       volumes:
         - name: config
           secret:
+{{- if eq .Values.useExternalConfig }}
+            secretName: {{ .Values.externalConfigSecretName }}
+{{- else }}
             secretName: {{ template "cortex.fullname" . }}
+{{- end }}
 {{- if .Values.alertmanager.extraVolumes }}
 {{ toYaml .Values.alertmanager.extraVolumes | indent 8}}
 {{- end }}

--- a/templates/configs-dep.yaml
+++ b/templates/configs-dep.yaml
@@ -28,9 +28,11 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
       annotations:
-{{- if not .Values.useExternalConfig }}      
+{{- if .Values.useExternalConfig }}      
+        checksum/config: {{ .Values.externalConfigVersion }}
+{{- else }}
         checksum/config: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
-{{- end}}  
+{{- end}}   
         {{- with .Values.configs.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/templates/configs-dep.yaml
+++ b/templates/configs-dep.yaml
@@ -104,7 +104,11 @@ spec:
       volumes:
         - name: config
           secret:
+{{- if eq .Values.useExternalConfig }}
+            secretName: {{ .Values.externalConfigSecretName }}
+{{- else }}
             secretName: {{ template "cortex.fullname" . }}
+{{- end }}
         {{- if .Values.configsdb_postgresql.enabled }}
         - name: postgres-password
           secret:

--- a/templates/configs-dep.yaml
+++ b/templates/configs-dep.yaml
@@ -28,7 +28,9 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
       annotations:
+{{- if not .Values.useExternalConfig }}      
         checksum/config: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+{{- end}}  
         {{- with .Values.configs.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/templates/distributor-dep.yaml
+++ b/templates/distributor-dep.yaml
@@ -29,9 +29,11 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
       annotations:
-{{- if not .Values.useExternalConfig }}      
+{{- if .Values.useExternalConfig }}      
+        checksum/config: {{ .Values.externalConfigVersion }}
+{{- else }}
         checksum/config: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
-{{- end}}  
+{{- end}}    
         {{- with .Values.distributor.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/templates/distributor-dep.yaml
+++ b/templates/distributor-dep.yaml
@@ -29,7 +29,9 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
       annotations:
+{{- if not .Values.useExternalConfig }}      
         checksum/config: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+{{- end}}  
         {{- with .Values.distributor.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/templates/distributor-dep.yaml
+++ b/templates/distributor-dep.yaml
@@ -96,7 +96,11 @@ spec:
       volumes:
         - name: config
           secret:
+{{- if eq .Values.useExternalConfig }}
+            secretName: {{ .Values.externalConfigSecretName }}
+{{- else }}
             secretName: {{ template "cortex.fullname" . }}
+{{- end }}
 {{- if .Values.distributor.extraVolumes }}
 {{ toYaml .Values.distributor.extraVolumes | indent 8}}
 {{- end }}

--- a/templates/ingester-dep.yaml
+++ b/templates/ingester-dep.yaml
@@ -29,7 +29,9 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
       annotations:
+{{- if not .Values.useExternalConfig }}      
         checksum/config: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+{{- end}}  
         {{- with .Values.ingester.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/templates/ingester-dep.yaml
+++ b/templates/ingester-dep.yaml
@@ -29,9 +29,11 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
       annotations:
-{{- if not .Values.useExternalConfig }}      
+{{- if .Values.useExternalConfig }}      
+        checksum/config: {{ .Values.externalConfigVersion }}
+{{- else }}
         checksum/config: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
-{{- end}}  
+{{- end}}   
         {{- with .Values.ingester.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/templates/ingester-dep.yaml
+++ b/templates/ingester-dep.yaml
@@ -102,7 +102,11 @@ spec:
       volumes:
         - name: config
           secret:
+{{- if eq .Values.useExternalConfig }}
+            secretName: {{ .Values.externalConfigSecretName }}
+{{- else }}
             secretName: {{ template "cortex.fullname" . }}
+{{- end }}
 {{- if .Values.ingester.extraVolumes }}
 {{ toYaml .Values.ingester.extraVolumes | indent 8}}
 {{- end }}

--- a/templates/nginx-dep.yaml
+++ b/templates/nginx-dep.yaml
@@ -28,7 +28,7 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
       annotations:
-        checksum/config: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+        checksum/config: {{ include (print $.Template.BasePath "/nginx-config.yaml") . | sha256sum }}
         {{- with .Values.nginx.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/templates/querier-dep.yaml
+++ b/templates/querier-dep.yaml
@@ -29,7 +29,9 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
       annotations:
+{{- if not .Values.useExternalConfig }}      
         checksum/config: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+{{- end}}  
         {{- with .Values.querier.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/templates/querier-dep.yaml
+++ b/templates/querier-dep.yaml
@@ -29,9 +29,11 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
       annotations:
-{{- if not .Values.useExternalConfig }}      
+{{- if .Values.useExternalConfig }}      
+        checksum/config: {{ .Values.externalConfigVersion }}
+{{- else }}
         checksum/config: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
-{{- end}}  
+{{- end}}    
         {{- with .Values.querier.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/templates/querier-dep.yaml
+++ b/templates/querier-dep.yaml
@@ -103,7 +103,11 @@ spec:
       volumes:
         - name: config
           secret:
+{{- if eq .Values.useExternalConfig }}
+            secretName: {{ .Values.externalConfigSecretName }}
+{{- else }}
             secretName: {{ template "cortex.fullname" . }}
+{{- end }}
 {{- if .Values.querier.extraVolumes }}
 {{ toYaml .Values.querier.extraVolumes | indent 8}}
 {{- end }}

--- a/templates/query-frontend-dep.yaml
+++ b/templates/query-frontend-dep.yaml
@@ -29,7 +29,9 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
       annotations:
+{{- if not .Values.useExternalConfig }}      
         checksum/config: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+{{- end}}  
         {{- with .Values.query_frontend.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/templates/query-frontend-dep.yaml
+++ b/templates/query-frontend-dep.yaml
@@ -96,7 +96,11 @@ spec:
       volumes:
         - name: config
           secret:
+{{- if eq .Values.useExternalConfig }}
+            secretName: {{ .Values.externalConfigSecretName }}
+{{- else }}
             secretName: {{ template "cortex.fullname" . }}
+{{- end }}
 {{- if .Values.query_frontend.extraVolumes }}
 {{ toYaml .Values.query_frontend.extraVolumes | indent 8}}
 {{- end }}

--- a/templates/query-frontend-dep.yaml
+++ b/templates/query-frontend-dep.yaml
@@ -29,9 +29,11 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
       annotations:
-{{- if not .Values.useExternalConfig }}      
+{{- if .Values.useExternalConfig }}      
+        checksum/config: {{ .Values.externalConfigVersion }}
+{{- else }}
         checksum/config: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
-{{- end}}  
+{{- end}}   
         {{- with .Values.query_frontend.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/templates/ruler-dep.yaml
+++ b/templates/ruler-dep.yaml
@@ -101,7 +101,11 @@ spec:
       volumes:
         - name: config
           secret:
+{{- if eq .Values.useExternalConfig }}
+            secretName: {{ .Values.externalConfigSecretName }}
+{{- else }}
             secretName: {{ template "cortex.fullname" . }}
+{{- end }}
 {{- if .Values.ruler.extraVolumes }}
 {{ toYaml .Values.ruler.extraVolumes | indent 8}}
 {{- end }}

--- a/templates/ruler-dep.yaml
+++ b/templates/ruler-dep.yaml
@@ -28,9 +28,11 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
       annotations:
-{{- if not .Values.useExternalConfig }}      
+{{- if .Values.useExternalConfig }}      
+        checksum/config: {{ .Values.externalConfigVersion }}
+{{- else }}
         checksum/config: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
-{{- end}}  
+{{- end}}   
         {{- with .Values.ruler.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/templates/ruler-dep.yaml
+++ b/templates/ruler-dep.yaml
@@ -28,7 +28,9 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
       annotations:
+{{- if not .Values.useExternalConfig }}      
         checksum/config: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+{{- end}}  
         {{- with .Values.ruler.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/templates/secret.yaml
+++ b/templates/secret.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.useExternalConfig }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -10,3 +11,4 @@ metadata:
     heritage: {{ .Release.Service }}
 data:
   cortex.yaml: {{ tpl (toYaml .Values.config) . | b64enc}}
+{{- end }}

--- a/templates/table-manager-dep.yaml
+++ b/templates/table-manager-dep.yaml
@@ -28,7 +28,9 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
       annotations:
+{{- if not .Values.useExternalConfig }}      
         checksum/config: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+{{- end}}  
         {{- with .Values.table_manager.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/templates/table-manager-dep.yaml
+++ b/templates/table-manager-dep.yaml
@@ -28,9 +28,11 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
       annotations:
-{{- if not .Values.useExternalConfig }}      
+{{- if .Values.useExternalConfig }}      
+        checksum/config: {{ .Values.externalConfigVersion }}
+{{- else }}
         checksum/config: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
-{{- end}}  
+{{- end}}   
         {{- with .Values.table_manager.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/templates/table-manager-dep.yaml
+++ b/templates/table-manager-dep.yaml
@@ -95,7 +95,11 @@ spec:
       volumes:
         - name: config
           secret:
+{{- if eq .Values.useExternalConfig }}
+            secretName: {{ .Values.externalConfigSecretName }}
+{{- else }}
             secretName: {{ template "cortex.fullname" . }}
+{{- end }}
 {{- if .Values.table_manager.extraVolumes }}
 {{ toYaml .Values.table_manager.extraVolumes | indent 8}}
 {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -33,6 +33,8 @@ serviceAccount:
   annotations: {}
 
 
+useExternalConfig: false
+externalConfigSecretName: "secret-with-config.yaml"
 config:
   auth_enabled: false
   ingester:

--- a/values.yaml
+++ b/values.yaml
@@ -35,6 +35,7 @@ serviceAccount:
 
 useExternalConfig: false
 externalConfigSecretName: "secret-with-config.yaml"
+externalConfigVersion: "0"
 config:
   auth_enabled: false
   ingester:


### PR DESCRIPTION
There is a need to support cortex configurations that are defined & managed outside of the helm chart. This quick PR adds support for cortex to reference a pre-existing secret for its config.

addresses #30 