### PR TITLE
Making Nginx optional

### DIFF
--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.ingress.enabled -}}
+{{- if and .Values.ingress.enabled .Values.nginx.enabled -}}
 {{- $fullName := include "cortex.fullname" . -}}
 {{- $svcPort := .Values.nginx.service.port -}}
 {{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}

--- a/templates/nginx-config.yaml
+++ b/templates/nginx-config.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.nginx.enabled }}
 kind: ConfigMap
 apiVersion: v1
 metadata:
@@ -56,3 +57,4 @@ data:
         }
       }
     }
+{{- end}}

--- a/templates/nginx-dep.yaml
+++ b/templates/nginx-dep.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.nginx.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -96,3 +97,4 @@ spec:
 {{- if .Values.nginx.extraVolumes }}
 {{ toYaml .Values.nginx.extraVolumes | indent 8}}
 {{- end }}
+{{- end}}

--- a/templates/nginx-svc.yaml
+++ b/templates/nginx-svc.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.nginx.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -23,3 +24,4 @@ spec:
   selector:
     app: {{ template "cortex.name" . }}-nginx
     release: {{ .Release.Name }}
+{{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -764,6 +764,7 @@ configs:
   env: []
 
 nginx:
+  enabled: true
   replicas: 2
   http_listen_port: 80
   config:


### PR DESCRIPTION
Instances of cortex that have their own frontdoor/proxy can turn off nginx now.

Addresses #29 

Signed-off-by: Ken Haines <ken@kenhaines.net>