### PR TITLE
Cortex uses DNS SRV records and looks for grpclb as the service name.…

### DIFF
--- a/templates/query-frontend-svc-headless.yaml
+++ b/templates/query-frontend-svc-headless.yaml
@@ -16,6 +16,7 @@ metadata:
 spec:
   type: ClusterIP
   clusterIP: None
+  publishNotReadyAddresses: true
   ports:
     - port: {{ .Values.config.server.http_listen_port }}
       protocol: TCP
@@ -23,7 +24,7 @@ spec:
       targetPort: http-metrics
     - port: {{ .Values.query_frontend.service.grpc_port }}
       protocol: TCP
-      name: grpc
+      name: grpclb
       targetPort: grpc
   selector:
     app: {{ template "cortex.name" . }}-query-frontend


### PR DESCRIPTION
Cortex uses DNS SRV records and looks for `grpclb` as the service name. Publishing not ready addresses is also required since the frontends wont go ready until a querier has connected, and the queriers wont find any frontend SRV records until they are ready

Addresses #33 

Signed-off-by: Roger Steneteg <rsteneteg@ea.com>