### PR TITLE
Fix target labels

### DIFF
--- a/templates/alertmanager-dep.yaml
+++ b/templates/alertmanager-dep.yaml
@@ -23,6 +23,7 @@ spec:
       labels:
         app: {{ template "cortex.name" . }}-alertmanager
         name: {{ template "cortex.name" . }}-alertmanager
+        target: alertmanager
         release: {{ .Release.Name }}
         {{- with .Values.alertmanager.podLabels }}
         {{- toYaml . | nindent 8 }}

--- a/templates/configs-dep.yaml
+++ b/templates/configs-dep.yaml
@@ -23,6 +23,7 @@ spec:
       labels:
         app: {{ template "cortex.name" . }}-configs
         name: {{ template "cortex.name" . }}-configs
+        target: configs
         release: {{ .Release.Name }}
         {{- with .Values.configs.podLabels }}
         {{- toYaml . | nindent 8 }}

--- a/templates/querier-dep.yaml
+++ b/templates/querier-dep.yaml
@@ -23,7 +23,7 @@ spec:
       labels:
         app: {{ template "cortex.name" . }}-querier
         name: {{ template "cortex.name" . }}-querier
-        target: distributor
+        target: querier
         release: {{ .Release.Name }}
         {{- with .Values.querier.podLabels }}
         {{- toYaml . | nindent 8 }}

--- a/templates/ruler-dep.yaml
+++ b/templates/ruler-dep.yaml
@@ -23,6 +23,7 @@ spec:
       labels:
         app: {{ template "cortex.name" . }}-ruler
         name: {{ template "cortex.name" . }}-ruler
+        target: ruler
         release: {{ .Release.Name }}
         {{- with .Values.ruler.podLabels }}
         {{- toYaml . | nindent 8 }}

--- a/templates/table-manager-dep.yaml
+++ b/templates/table-manager-dep.yaml
@@ -23,6 +23,7 @@ spec:
       labels:
         app: {{ template "cortex.name" . }}-table-manager
         name: {{ template "cortex.name" . }}-table-manager
+        target: table-manager
         release: {{ .Release.Name }}
         {{- with .Values.table_manager.podLabels }}
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
The target label is missing on several deployments and it is wrong on the querier deployment.
This simple PR is to have a consistent and correct target label on all deployed components.

Signed-off-by: Thibaut Charry <ttcharry@gmail.com>