### PR TITLE
Fix values file duplicate config.storage section

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -57,9 +57,6 @@ config:
     enforce_metric_name: false
     reject_old_samples: true
     reject_old_samples_max_age: 168h
-    # See https://github.com/cortexproject/cortex/blob/master/docs/configuration/config-file-reference.md#storage_config
-  storage:
-    engine: chunks
   schema:
     configs:
       - from: 2019-07-29
@@ -82,6 +79,7 @@ config:
       use_gzip_compression: true
   # See https://github.com/cortexproject/cortex/blob/master/docs/configuration/config-file-reference.md#storage_config
   storage:
+    engine: chunks
     cassandra:
       addresses: # configure cassandra addresses here.
       keyspace: cortex # configure desired keyspace here.


### PR DESCRIPTION
In #50, the `config.storage` section in the values.yaml file has been duplicated by mistake.
This causes `helm lint` to fail:
```
helm lint .
==> Linting .
[ERROR] templates/: template: cortex/templates/table-manager-svc.yaml:1:7: executing "cortex/templates/table-manager-svc.yaml" at <ne .Values.config.storage.engine "blocks">: error calling ne: incompatible types for comparison

Error: 1 chart(s) linted, 1 chart(s) failed
```
The `engine` key is moved to the already existing `config.storage` section.

Signed-off-by: Thibaut Charry <ttcharry@gmail.com>