### PR TITLE
add grpc ports to store gateway pods and service

### DIFF
--- a/templates/store-gateway-statefulset.yaml
+++ b/templates/store-gateway-statefulset.yaml
@@ -132,6 +132,9 @@ spec:
             - name: http-metrics
               containerPort: {{ .Values.config.server.http_listen_port }}
               protocol: TCP
+            - name: grpc
+              containerPort: {{ .Values.config.server.grpc_listen_port }}
+              protocol: TCP            
           livenessProbe:
             {{- toYaml .Values.store_gateway.livenessProbe | nindent 12 }}
           readinessProbe:

--- a/templates/store-gateway-svc.yaml
+++ b/templates/store-gateway-svc.yaml
@@ -22,6 +22,10 @@ spec:
       protocol: TCP
       name: http-metrics
       targetPort: http-metrics
+    - port: {{ .Values.store_gateway.service.grpc_port }}
+      protocol: TCP
+      name: grpclb
+      targetPort: grpc      
   selector:
     app: {{ template "cortex.name" . }}-store-gateway
     release: {{ .Release.Name }}

--- a/values.yaml
+++ b/values.yaml
@@ -899,6 +899,7 @@ store_gateway:
 
   service:
     port: 80
+    grpc_port: 9095
     annotations: {}
     labels: {}
 


### PR DESCRIPTION
The store gateway utilizes GRPC for data access, however, these ports are missing from the template YAML. This PR corrects that.