### PR TITLE
updating default cortex version in chart to 1.4.0

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,17 +1,17 @@
 apiVersion: v2
-version: 0.1.2
-appVersion: v1.1.0
+version: 0.2.0
+appVersion: v1.4.0
 description: 'Cortex'
 engine: gotpl
 home: https://cortexmetrics.io/
 icon: https://avatars2.githubusercontent.com/u/43045022?s=200&v=4
 kubeVersion: ^1.10.0-0
 maintainers:
-- email: cortex-team@googlegroups.com
-  name: Cortex Maintainers
+  - email: cortex-team@googlegroups.com
+    name: Cortex Maintainers
 name: cortex
 sources:
-- https://github.com/cortexproject/cortex-helm-chart
+  - https://github.com/cortexproject/cortex-helm-chart
 dependencies:
   - name: memcached
     alias: memcached

--- a/values.yaml
+++ b/values.yaml
@@ -3,9 +3,8 @@
 
 image:
   repository: quay.io/cortexproject/cortex
-  tag: v1.1.0
+  tag: v1.4.0
   pullPolicy: IfNotPresent
-
 
   ## Optionally specify an array of imagePullSecrets.
   ## Secrets must be manually created in the namespace.
@@ -469,7 +468,6 @@ ingester:
     ## Useful if the volume's root directory is not empty
     ##
     subPath: ''
-
 
     ## Ingester data Persistent Volume Storage Class
     ## If defined, storageClassName: <storageClass>
@@ -1003,7 +1001,6 @@ store_gateway:
     ##
     subPath: ''
 
-
     ## Store-gateway data Persistent Volume Storage Class
     ## If defined, storageClassName: <storageClass>
     ## If set to "-", storageClassName: "", which disables dynamic provisioning
@@ -1115,7 +1112,6 @@ compactor:
     ## Useful if the volume's root directory is not empty
     ##
     subPath: ''
-
 
     ## compactor data Persistent Volume Storage Class
     ## If defined, storageClassName: <storageClass>


### PR DESCRIPTION
Also bumping the chart version up, in prep for publishing a chart repo url to assist with helm install without cloning the whole repo.
Signed-off-by: Ken Haines <khaines@microsoft.com>