### PR TITLE
Change the ingester service to headless

### DIFF
--- a/templates/ingester-svc.yaml
+++ b/templates/ingester-svc.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "cortex.fullname" . }}-ingester
+  name: {{ template "cortex.fullname" . }}-ingester-headless
   namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "cortex.name" . }}-ingester
@@ -15,6 +15,7 @@ metadata:
     {{- toYaml .Values.ingester.annotations | nindent 4 }}
 spec:
   type: ClusterIP
+  clusterIP: None
   ports:
     - port: {{ .Values.config.server.http_listen_port }}
       protocol: TCP

--- a/values.yaml
+++ b/values.yaml
@@ -135,6 +135,11 @@ config:
     shard_by_all_labels: true
     pool:
       health_check_ingesters: true
+  memberlist:
+    join_members: []
+    ## add here the service name of the ingesters
+    ## if using memberlist discovery, eg:
+    #  - cortex-ingester-headless
   querier:
     active_query_tracker_dir: /data/cortex/querier
     query_ingesters_within: 12h


### PR DESCRIPTION
Memberlist discovery can be configured using DNS. This commit changes the ingester service to headless, so memberlist can properly build the ring.