### PR TITLE
deploy alertmanager headless service when StatefulSet is used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## master / unreleased
 
 * [ENHANCEMENT] Compactor service is no longer created if compactor is disabled. #82
+* [ENHANCEMENT] Headless service for alert manager is only enabled when the alert manager is deployed as a stateful set. #91
 
 ## 0.2.0 / 2020-10-25
 

--- a/templates/alertmanager-svc-headless.yaml
+++ b/templates/alertmanager-svc-headless.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.alertmanager.statefulSet.enabled -}}
 {{- $clusterPort := regexReplaceAll ".+[:]" (default "0.0.0.0:9094" .Values.config.alertmanager.cluster_bind_address) "" -}}
 apiVersion: v1
 kind: Service
@@ -28,3 +29,4 @@ spec:
   selector:
     app: {{ template "cortex.name" . }}-alertmanager
     release: {{ .Release.Name }}
+{{- end -}}


### PR DESCRIPTION
currently, the headless service for the alertmanager is deployed in all configurations. However, it is only needed when the alert manager is a stateful set.