### PR TITLE
"kubernetes-charts.storage.googleapis.com" is deprecated

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -16,15 +16,15 @@ dependencies:
   - name: memcached
     alias: memcached
     version: 3.2.3
-    repository: https://kubernetes-charts.storage.googleapis.com/
+    repository: https://charts.helm.sh/stable
     condition: memcached.enabled
   - name: memcached
     alias: memcached-index-read
     version: 3.2.3
-    repository: https://kubernetes-charts.storage.googleapis.com/
+    repository: https://charts.helm.sh/stable
     condition: memcached-index-read.enabled
   - name: memcached
     alias: memcached-index-write
     version: 3.2.3
-    repository: https://kubernetes-charts.storage.googleapis.com/
+    repository: https://charts.helm.sh/stable
     condition: memcached-index-write.enabled


### PR DESCRIPTION
The repository was deleted, and users that ran "helm dependency update" before Nov 13 2020 don't see any issues. Still, new users cannot download Memcache from googleapis.com and need to change the repository URL to https://charts.helm.sh/stable to run the deployment. 

this fix issues https://github.com/cortexproject/cortex-helm-chart/issues/98 