### PR TITLE
as nginx uses http 1.0 by default, which is very old and istio servic…

### DIFF
--- a/templates/nginx-config.yaml
+++ b/templates/nginx-config.yaml
@@ -37,6 +37,7 @@ data:
         proxy_connect_timeout 300s;
         proxy_send_timeout 300s;
         proxy_read_timeout 300s;
+        proxy_http_version 1.1;
 
         location = /healthz {
           return 200 'alive';


### PR DESCRIPTION
…e mesh wont support 1.0 without making changes to istio config. Instead of chaning istio config we can set 1.1 by default in nginx config file