### PR TITLE
Expose new HTTP API paths for remote-write and Query frontend to nginx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## master / unreleased
 
+* [ENHANCEMENT] Expose new HTTP API paths for remote-write and Query frontend to nginx #103
 * [ENHANCEMENT] Compactor service is no longer created if compactor is disabled. #82
 * [ENHANCEMENT] Headless service for alert manager is only enabled when the alert manager is deployed as a stateful set. #91
 * [ENHANCEMENT] Improved memcached configuration template, with support for both chunks & block storage caches. #92

--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ Source code can be found [here](https://cortexmetrics.io/)
 | compactor.terminationGracePeriodSeconds | int | `240` |  |
 | compactor.tolerations | list | `[]` |  |
 | config.alertmanager.external_url | string | `"/api/prom/alertmanager"` |  |
+| config.api.prometheus_http_prefix | string | `"/prometheus"` |  |
 | config.auth_enabled | bool | `false` |  |
 | config.chunk_store.chunk_cache_config.memcached.expiration | string | `"1h"` |  |
 | config.chunk_store.chunk_cache_config.memcached_client.timeout | string | `"1s"` |  |

--- a/templates/nginx-config.yaml
+++ b/templates/nginx-config.yaml
@@ -55,6 +55,12 @@ data:
           proxy_pass      http://{{ template "cortex.fullname" . }}-distributor.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.config.server.http_listen_port }}$request_uri;
         }
 
+        ## New Remote write API. Ref: https://cortexmetrics.io/docs/api/#remote-write
+        location = /api/v1/push {
+          proxy_pass      http://{{ template "cortex.fullname" . }}-distributor.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.config.server.http_listen_port }}$request_uri;
+        }
+
+
         # Alertmanager Config
         location ~ /api/prom/alertmanager/.* {
           proxy_pass      http://{{ template "cortex.fullname" . }}-alertmanager.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.config.server.http_listen_port }}$request_uri;
@@ -86,6 +92,16 @@ data:
         location ~ /api/prom/.* {
           proxy_pass      http://{{ template "cortex.fullname" . }}-query-frontend.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.config.server.http_listen_port }}$request_uri;
         }
+
+        ## New Query frontend APIs as per https://cortexmetrics.io/docs/api/#querier--query-frontend
+        location ~ ^{{.Values.config.api.prometheus_http_prefix}}/api/v1/(read|metadata|labels|series|query_range|query) {
+          proxy_pass      http://{{ template "cortex.fullname" . }}-query-frontend.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.config.server.http_listen_port }}$request_uri;
+        }
+
+        location ~ {{.Values.config.api.prometheus_http_prefix}}/api/v1/label/.* {
+          proxy_pass      http://{{ template "cortex.fullname" . }}-query-frontend.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.config.server.http_listen_port }}$request_uri;
+        }
+
       }
     }
 {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -44,6 +44,8 @@ externalConfigVersion: '0'
 
 config:
   auth_enabled: false
+  api:
+    prometheus_http_prefix: "/prometheus"
   ingester:
     max_transfer_retries: 0
     lifecycler:


### PR DESCRIPTION
- Adds new remote write API to nginx. 
    - `/api/v1/push`
    - API ref: https://cortexmetrics.io/docs/api/#remote-write
- Adds new query frontend APIs to nginx
    - `/prometheus/api/v1/label/.*`
    - `^/prometheus/api/v1/(read|metadata|labels|series|query_range|query)`
    - API ref: https://cortexmetrics.io/docs/api/#querier--query-frontend