### PR TITLE
updating default image tag for cortex

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -3,7 +3,7 @@
 
 image:
   repository: quay.io/cortexproject/cortex
-  tag: v1.4.0
+  tag: v1.6.0
   pullPolicy: IfNotPresent
 
   ## Optionally specify an array of imagePullSecrets.


### PR DESCRIPTION
Latest stable is 1.6, but values still contained 1.4

Signed-off-by: Ken Haines <khaines@microsoft.com>