### PR TITLE
Fix ingress rule config for kubernetes 1.19+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## master / unreleased
+* [BUGFIX] Ingress config is fixed for Kubernetes versions 1.19+ 
 
 ## 0.3.0 / 2021-01-21
 

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -39,8 +39,15 @@ spec:
         {{- range .paths }}
           - path: {{ . }}
             backend:
+            {{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+            {{- else -}}
               serviceName: {{ $fullName }}
               servicePort: {{ $svcPort }}
+            {{- end }}
         {{- end }}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
The current ingress config is giving the following error:
```
Error: unable to build kubernetes objects from release manifest: error validating "": error validating data: [ValidationError(Ingress.spec.rules[0].http.paths[0].backend): unknown field "serviceName" in io.k8s.api.networking.v1.IngressBackend, ValidationError(Ingress.spec.rules[0].http.paths[0].backend): unknown field "servicePort" in io.k8s.api.networking.v1.IngressBackend]
```
This is an attempt to fix this issue.