### PR TITLE
issue #124: switch memcached chart to bitnami helm repo

### DIFF
--- a/Chart.lock
+++ b/Chart.lock
@@ -1,24 +1,24 @@
 dependencies:
 - name: memcached
-  repository: https://charts.helm.sh/stable
-  version: 3.2.3
+  repository: https://charts.bitnami.com/bitnami
+  version: 5.5.1
 - name: memcached
-  repository: https://charts.helm.sh/stable
-  version: 3.2.3
+  repository: https://charts.bitnami.com/bitnami
+  version: 5.5.1
 - name: memcached
-  repository: https://charts.helm.sh/stable
-  version: 3.2.3
+  repository: https://charts.bitnami.com/bitnami
+  version: 5.5.1
 - name: memcached
-  repository: https://charts.helm.sh/stable
-  version: 3.2.3
+  repository: https://charts.bitnami.com/bitnami
+  version: 5.5.1
 - name: memcached
-  repository: https://charts.helm.sh/stable
-  version: 3.2.3
+  repository: https://charts.bitnami.com/bitnami
+  version: 5.5.1
 - name: memcached
-  repository: https://charts.helm.sh/stable
-  version: 3.2.3
+  repository: https://charts.bitnami.com/bitnami
+  version: 5.5.1
 - name: memcached
-  repository: https://charts.helm.sh/stable
-  version: 3.2.3
-digest: sha256:a59f91a3faa39ae3bb3cade308a65c93ca770a4364beb65ef3ed3280eb12db23
-generated: "2021-01-21T09:25:16.322064-08:00"
+  repository: https://charts.bitnami.com/bitnami
+  version: 5.5.1
+digest: sha256:944a782569cae3c73869587c9efbd85dd4841fb28d648fdaf6fd72e9c0dfd7d2
+generated: "2021-02-19T16:22:13.325783-08:00"

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -15,39 +15,39 @@ sources:
 dependencies:
   - name: memcached
     alias: memcached
-    version: 3.2.3
-    repository: https://charts.helm.sh/stable
+    version: 5.5.1
+    repository: https://charts.bitnami.com/bitnami
     condition: memcached.enabled
   - name: memcached
     alias: memcached-index-read
-    version: 3.2.3
-    repository: https://charts.helm.sh/stable
+    version: 5.5.1
+    repository: https://charts.bitnami.com/bitnami
     condition: memcached-index-read.enabled
   - name: memcached
     alias: memcached-index-write
-    version: 3.2.3
-    repository: https://charts.helm.sh/stable
+    version: 5.5.1
+    repository: https://charts.bitnami.com/bitnami
     condition: memcached-index-write.enabled
   - name: memcached
     alias: memcached-frontend
-    version: 3.2.3
-    repository: https://charts.helm.sh/stable
+    version: 5.5.1
+    repository: https://charts.bitnami.com/bitnami
     condition: memcached-frontend.enabled
   - name: memcached
     alias: memcached-blocks-index
-    version: 3.2.3
-    repository: https://charts.helm.sh/stable
+    version: 5.5.1
+    repository: https://charts.bitnami.com/bitnami
     tags:
       - blocks-storage-memcached
   - name: memcached
     alias: memcached-blocks
-    version: 3.2.3
-    repository: https://charts.helm.sh/stable
+    version: 5.5.1
+    repository: https://charts.bitnami.com/bitnami
     tags:
       - blocks-storage-memcached
   - name: memcached
     alias: memcached-blocks-metadata
-    version: 3.2.3
-    repository: https://charts.helm.sh/stable
+    version: 5.5.1
+    repository: https://charts.bitnami.com/bitnami
     tags:
       - blocks-storage-memcached

--- a/ct.yaml
+++ b/ct.yaml
@@ -5,4 +5,5 @@ charts:
   - "./"
 chart-repos:
   - base-charts=https://charts.helm.sh/stable
+  - bitnami=https://charts.bitnami.com/bitnami
 helm-extra-args: --timeout 600s

--- a/values.yaml
+++ b/values.yaml
@@ -1205,6 +1205,7 @@ compactor:
 # chunk caching
 memcached:
   enabled: false
+  architecture: "high-availability"
   replicaCount: 2
   pdbMinAvailable: 1
   memcached:
@@ -1239,6 +1240,7 @@ memcached:
 # index read caching
 memcached-index-read:
   enabled: false
+  architecture: "high-availability"
   replicaCount: 2
   # pdbMinAvailable: 1
   # image: memcached:1.5.7-alpine
@@ -1274,6 +1276,7 @@ memcached-index-read:
 # index write caching
 memcached-index-write:
   enabled: false
+  architecture: "high-availability"
   replicaCount: 2
   # dpdbMinAvailable: 1
   # image: memcached:1.5.7-alpine
@@ -1308,6 +1311,7 @@ memcached-index-write:
 
 memcached-frontend:
   enabled: false
+  architecture: "high-availability"
   replicaCount: 2
   # dpdbMinAvailable: 1
   # image: memcached:1.5.7-alpine
@@ -1328,6 +1332,7 @@ memcached-frontend:
 
 memcached-blocks-index:
   # enabled/disabled via the tags.blocks-storage-memcached boolean
+  architecture: "high-availability"
   replicaCount: 2
   # dpdbMinAvailable: 1
   # image: memcached:1.5.7-alpine
@@ -1348,6 +1353,7 @@ memcached-blocks-index:
 
 memcached-blocks:
   # enabled/disabled via the tags.blocks-storage-memcached boolean
+  architecture: "high-availability"
   replicaCount: 2
   # dpdbMinAvailable: 1
   # image: memcached:1.5.7-alpine
@@ -1368,6 +1374,7 @@ memcached-blocks:
 
 memcached-blocks-metadata:
   # enabled/disabled via the tags.blocks-storage-memcached boolean
+  architecture: "high-availability"
   replicaCount: 2
   # dpdbMinAvailable: 1
   # image: memcached:1.5.7-alpine


### PR DESCRIPTION
Replace the stable/memcached subcharts with bitnami/memcached. This chart is currently the supported memcached deployment method and allows setting labels on ServiceMonitors bundled with the chart.