### PR TITLE
feat: allow relabel config for servicemonitors

### DIFF
--- a/templates/alertmanager-servicemonitor.yaml
+++ b/templates/alertmanager-servicemonitor.yaml
@@ -31,4 +31,8 @@ spec:
     {{- if .Values.alertmanager.serviceMonitor.scrapeTimeout }}
     scrapeTimeout: {{ .Values.alertmanager.serviceMonitor.scrapeTimeout }}
     {{- end }}
+    {{- if .Values.alertmanager.serviceMonitor.relabelings }}
+    relabelings:
+{{ toYaml .Values.alertmanager.serviceMonitor.relabelings | indent 6 }}
+    {{- end }}
 {{- end }}

--- a/templates/compactor-servicemonitor.yaml
+++ b/templates/compactor-servicemonitor.yaml
@@ -31,4 +31,8 @@ spec:
     {{- if .Values.compactor.serviceMonitor.scrapeTimeout }}
     scrapeTimeout: {{ .Values.compactor.serviceMonitor.scrapeTimeout }}
     {{- end }}
+    {{- if .Values.compactor.serviceMonitor.relabelings }}
+    relabelings:
+{{ toYaml .Values.compactor.serviceMonitor.relabelings | indent 6 }}
+    {{- end }}
 {{- end }}

--- a/templates/configs-servicemonitor.yaml
+++ b/templates/configs-servicemonitor.yaml
@@ -31,4 +31,8 @@ spec:
     {{- if .Values.configs.serviceMonitor.scrapeTimeout }}
     scrapeTimeout: {{ .Values.configs.serviceMonitor.scrapeTimeout }}
     {{- end }}
+    {{- if .Values.configs.serviceMonitor.relabelings }}
+    relabelings:
+{{ toYaml .Values.configs.serviceMonitor.relabelings | indent 6 }}
+    {{- end }}
 {{- end }}

--- a/templates/distributor-servicemonitor.yaml
+++ b/templates/distributor-servicemonitor.yaml
@@ -31,4 +31,8 @@ spec:
     {{- if .Values.distributor.serviceMonitor.scrapeTimeout }}
     scrapeTimeout: {{ .Values.distributor.serviceMonitor.scrapeTimeout }}
     {{- end }}
+    {{- if .Values.distributor.serviceMonitor.relabelings }}
+    relabelings:
+{{ toYaml .Values.distributor.serviceMonitor.relabelings | indent 6 }}
+  {{- end }}
 {{- end }}

--- a/templates/ingester-servicemonitor.yaml
+++ b/templates/ingester-servicemonitor.yaml
@@ -31,4 +31,8 @@ spec:
     {{- if .Values.ingester.serviceMonitor.scrapeTimeout }}
     scrapeTimeout: {{ .Values.ingester.serviceMonitor.scrapeTimeout }}
     {{- end }}
+    {{- if .Values.ingester.serviceMonitor.relabelings }}
+    relabelings:
+{{ toYaml .Values.ingester.serviceMonitor.relabelings | indent 6 }}
+    {{- end }}
 {{- end }}

--- a/templates/querier-servicemonitor.yaml
+++ b/templates/querier-servicemonitor.yaml
@@ -31,4 +31,8 @@ spec:
     {{- if .Values.querier.serviceMonitor.scrapeTimeout }}
     scrapeTimeout: {{ .Values.querier.serviceMonitor.scrapeTimeout }}
     {{- end }}
+    {{- if .Values.querier.serviceMonitor.relabelings }}
+    relabelings:
+{{ toYaml .Values.querier.serviceMonitor.relabelings | indent 6 }}
+    {{- end }}
 {{- end }}

--- a/templates/query-frontend-servicemonitor.yaml
+++ b/templates/query-frontend-servicemonitor.yaml
@@ -31,4 +31,8 @@ spec:
     {{- if .Values.query_frontend.serviceMonitor.scrapeTimeout }}
     scrapeTimeout: {{ .Values.query_frontend.serviceMonitor.scrapeTimeout }}
     {{- end }}
+    {{- if .Values.query_frontend.serviceMonitor.relabelings }}
+    relabelings:
+{{ toYaml .Values.query_frontend.serviceMonitor.relabelings | indent 6 }}
+    {{- end }}
 {{- end }}

--- a/templates/ruler-servicemonitor.yaml
+++ b/templates/ruler-servicemonitor.yaml
@@ -31,4 +31,8 @@ spec:
     {{- if .Values.ruler.serviceMonitor.scrapeTimeout }}
     scrapeTimeout: {{ .Values.ruler.serviceMonitor.scrapeTimeout }}
     {{- end }}
+    {{- if .Values.ruler.serviceMonitor.relabelings }}
+    relabelings:
+{{ toYaml .Values.ruler.serviceMonitor.relabelings | indent 6 }}
+    {{- end }}
 {{- end }}

--- a/templates/store-gateway-servicemonitor.yaml
+++ b/templates/store-gateway-servicemonitor.yaml
@@ -31,4 +31,8 @@ spec:
     {{- if .Values.store_gateway.serviceMonitor.scrapeTimeout }}
     scrapeTimeout: {{ .Values.store_gateway.serviceMonitor.scrapeTimeout }}
     {{- end }}
+    {{- if .Values.store_gateway.serviceMonitor.relabelings }}
+    relabelings:
+{{ toYaml .Values.store_gateway.serviceMonitor.relabelings | indent 6 }}
+    {{- end }}
 {{- end }}

--- a/templates/table-manager-servicemonitor.yaml
+++ b/templates/table-manager-servicemonitor.yaml
@@ -31,4 +31,8 @@ spec:
     {{- if .Values.table_manager.serviceMonitor.scrapeTimeout }}
     scrapeTimeout: {{ .Values.table_manager.serviceMonitor.scrapeTimeout }}
     {{- end }}
+    {{- if .Values.table_manager.serviceMonitor.relabelings }}
+    relabelings:
+{{ toYaml .Values.table_manager.serviceMonitor.relabelings | indent 6 }}
+    {{- end }}
 {{- end }}


### PR DESCRIPTION
Allows specifying relabel configs for the service monitors. Might be helpful, for some?