### PR TITLE
Upgrade memcached and add sa token mount value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * [FEATURE] Support dynamic configuration of Ruler and AlertManager using sidecar #150
 * [ENHANCEMENT] Enable/Disable security & container security context #158
 * [ENHANCEMENT] ServiceMonitors: add options to configure metricRelabelings and relabelings #165
+* [ENHANCEMENT] Support specification of whether service accounts should automount token by adding value for Cortex service account and upgrading memcached dependency to version which includes same change #142
 * [BUGFIX] Fixed the default label used in pod affinity expression #162
 * [BUGFIX] Fix label and annotation overrides for services (thanks @kwangil-ha) #164
 * [BUGFIX] Fix store gateway service name regression introduced in (#144) #166

--- a/Chart.lock
+++ b/Chart.lock
@@ -1,24 +1,24 @@
 dependencies:
 - name: memcached
   repository: https://charts.bitnami.com/bitnami
-  version: 5.5.1
+  version: 5.13.0
 - name: memcached
   repository: https://charts.bitnami.com/bitnami
-  version: 5.5.1
+  version: 5.13.0
 - name: memcached
   repository: https://charts.bitnami.com/bitnami
-  version: 5.5.1
+  version: 5.13.0
 - name: memcached
   repository: https://charts.bitnami.com/bitnami
-  version: 5.5.1
+  version: 5.13.0
 - name: memcached
   repository: https://charts.bitnami.com/bitnami
-  version: 5.5.1
+  version: 5.13.0
 - name: memcached
   repository: https://charts.bitnami.com/bitnami
-  version: 5.5.1
+  version: 5.13.0
 - name: memcached
   repository: https://charts.bitnami.com/bitnami
-  version: 5.5.1
-digest: sha256:944a782569cae3c73869587c9efbd85dd4841fb28d648fdaf6fd72e9c0dfd7d2
-generated: "2021-02-19T16:22:13.325783-08:00"
+  version: 5.13.0
+digest: sha256:81cd2126bfd91749911ea4aeaae861953576e8bedd9d357ac5e27cd2c7462b74
+generated: "2021-06-22T13:58:03.865352-07:00"

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -14,39 +14,39 @@ sources:
 dependencies:
   - name: memcached
     alias: memcached
-    version: 5.5.1
+    version: 5.13.0
     repository: https://charts.bitnami.com/bitnami
     condition: memcached.enabled
   - name: memcached
     alias: memcached-index-read
-    version: 5.5.1
+    version: 5.13.0
     repository: https://charts.bitnami.com/bitnami
     condition: memcached-index-read.enabled
   - name: memcached
     alias: memcached-index-write
-    version: 5.5.1
+    version: 5.13.0
     repository: https://charts.bitnami.com/bitnami
     condition: memcached-index-write.enabled
   - name: memcached
     alias: memcached-frontend
-    version: 5.5.1
+    version: 5.13.0
     repository: https://charts.bitnami.com/bitnami
     condition: memcached-frontend.enabled
   - name: memcached
     alias: memcached-blocks-index
-    version: 5.5.1
+    version: 5.13.0
     repository: https://charts.bitnami.com/bitnami
     tags:
       - blocks-storage-memcached
   - name: memcached
     alias: memcached-blocks
-    version: 5.5.1
+    version: 5.13.0
     repository: https://charts.bitnami.com/bitnami
     tags:
       - blocks-storage-memcached
   - name: memcached
     alias: memcached-blocks-metadata
-    version: 5.5.1
+    version: 5.13.0
     repository: https://charts.bitnami.com/bitnami
     tags:
       - blocks-storage-memcached

--- a/README.md
+++ b/README.md
@@ -657,6 +657,7 @@ Kubernetes: `^1.19.0-0`
 | serviceAccount.annotations | object | `{}` |  |
 | serviceAccount.create | bool | `true` |  |
 | serviceAccount.name | string | `nil` |  |
+| serviceAccount.automountServiceAccountToken | bool | `true` |  |
 | store_gateway.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].podAffinityTerm.labelSelector.matchExpressions[0].key | string | `"target"` |  |
 | store_gateway.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].podAffinityTerm.labelSelector.matchExpressions[0].operator | string | `"In"` |  |
 | store_gateway.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].podAffinityTerm.labelSelector.matchExpressions[0].values[0] | string | `"store-gateway"` |  |

--- a/templates/serviceaccount.yaml
+++ b/templates/serviceaccount.yaml
@@ -7,4 +7,5 @@ metadata:
     {{- include "cortex.labels" . | nindent 4 }}
   annotations:
     {{- toYaml .Values.serviceAccount.annotations | nindent 4 }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
 {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -37,6 +37,7 @@ serviceAccount:
   create: true
   name:
   annotations: {}
+  automountServiceAccountToken: true
 
 useExternalConfig: false
 externalConfigSecretName: 'secret-with-config.yaml'


### PR DESCRIPTION
* Upgrades memcached helm chart from 5.5.1 to 5.13.0 which adds support
  for specifying service account association and creation
* Adds service account value for whether to automount the token

Signed-off-by: Ryan Probus <ryan.probus@appian.com>