### PR TITLE
Add headless service for distributor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * [ENHANCEMENT] Expose `client_max_body_size` config for nginx max request body size #137
 * [ENHANCEMENT] Adding option to add custom headers (ex. X-Scope-OrgID) to NGINX from values.yaml (key `nginx.config.setHeaders`). #127
-* [ENHANCEMENT] Headless service for distributor to allow GRPC load balancing
+* [ENHANCEMENT] Headless service for distributor to allow GRPC load balancing #148
 
 ## 0.4.1 / 2021-03-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * [ENHANCEMENT] Expose `client_max_body_size` config for nginx max request body size #137
 * [ENHANCEMENT] Adding option to add custom headers (ex. X-Scope-OrgID) to NGINX from values.yaml (key `nginx.config.setHeaders`). #127
+* [ENHANCEMENT] Headless service for distributor to allow GRPC load balancing
 
 ## 0.4.1 / 2021-03-22
 

--- a/templates/distributor-svc-headless.yaml
+++ b/templates/distributor-svc-headless.yaml
@@ -1,0 +1,31 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "cortex.fullname" . }}-distributor-headless
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "cortex.name" . }}-distributor
+    chart: {{ template "cortex.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    {{- with .Values.distributor.service.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  annotations:
+    {{- toYaml .Values.distributor.service.annotations | nindent 4 }}
+spec:
+  type: ClusterIP
+  clusterIP: None
+  publishNotReadyAddresses: true
+  ports:
+    - port: {{ .Values.config.server.http_listen_port }}
+      protocol: TCP
+      name: http-metrics
+      targetPort: http-metrics
+    - port: {{ .Values.config.server.grpc_listen_port }}
+      protocol: TCP
+      name: grpclb
+      targetPort: grpc
+  selector:
+    app: {{ template "cortex.name" . }}-distributor
+    release: {{ .Release.Name }}


### PR DESCRIPTION
Create headless service for distributor to allow GRPC load balancing when using HTTP over GRPC for communicating with distributor.