### PR TITLE
Add tenant overrides config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * [ENHANCEMENT] Expose `client_max_body_size` config for nginx max request body size #137
 * [ENHANCEMENT] Adding option to add custom headers (ex. X-Scope-OrgID) to NGINX from values.yaml (key `nginx.config.setHeaders`). #127
+* [ENHANCEMENT] adding `tenant_overrides` config for applying limits to each tenant
 
 ## 0.4.1 / 2021-03-22
 

--- a/templates/tenant-overrides-secret.yaml
+++ b/templates/tenant-overrides-secret.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.tenantOverridesConfig.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "cortex.fullname" . }}-tenant-overrides
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "cortex.name" . }}
+    chart: {{ template "cortex.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+data:
+  overrides.yaml: {{ tpl (toYaml .Values.tenantOverridesConfig.overridesYaml) . | b64enc}}
+{{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -1406,3 +1406,10 @@ configsdb_postgresql:
     existing_secret:
       name:
       key:
+
+# Add tenant level overrides
+# ref: https://cortexmetrics.io/docs/guides/overrides-exporter/
+tenantOverridesConfig:
+  enabled: false
+  overridesYaml:
+    overrides: {}


### PR DESCRIPTION
Creates a secret that stores the override configs data.
Enables setting specific limits to different tenants.

Ref: https://cortexmetrics.io/docs/guides/overrides-exporter/