### PR TITLE
Fix alertmanager priorityClassName

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * [ENHANCEMENT] Expose `client_max_body_size` config for nginx max request body size #137
 * [ENHANCEMENT] Adding option to add custom headers (ex. X-Scope-OrgID) to NGINX from values.yaml (key `nginx.config.setHeaders`). #127
+* [BUGFIX] Fixed `priorityClassName` in alertmanager deployment configuration. #155
 
 ## 0.4.1 / 2021-03-22
 

--- a/templates/alertmanager-dep.yaml
+++ b/templates/alertmanager-dep.yaml
@@ -41,7 +41,7 @@ spec:
     spec:
       serviceAccountName: {{ template "cortex.serviceAccountName" . }}
     {{- if .Values.alertmanager.priorityClassName }}
-      priorityClassName: {{ .Values.query_frontend.priorityClassName }}
+      priorityClassName: {{ .Values.alertmanager.priorityClassName }}
     {{- end }}
       securityContext:
         {{- toYaml .Values.alertmanager.securityContext | nindent 8 }}


### PR DESCRIPTION
This PR fixes `priorityClassName` in alertmanager deployment.