### PR TITLE
fix pdb manifests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * [BUGFIX] Fixed `priorityClassName` in alertmanager deployment configuration. #155
 * [BUGFIX] Replacing deprecated (in Cortex 1.9) configuration with appropriate replacements (max_look_back_period -> max_query_lookback & compress_responses -> response_compression_enabled). #154
 * [BUGFIX] Added missing ServiceMonitors `additionalLabels` placeholders in `values.yaml`. #146
+* [BUGFIX] Fix PodDisruptionBudget templates. #156
 
 ## 0.4.1 / 2021-03-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 * [BUGFIX] Fixed `priorityClassName` in alertmanager deployment configuration. #155
 * [BUGFIX] Replacing deprecated (in Cortex 1.9) configuration with appropriate replacements (max_look_back_period -> max_query_lookback & compress_responses -> response_compression_enabled). #154
 * [BUGFIX] Added missing ServiceMonitors `additionalLabels` placeholders in `values.yaml`. #146
-* [BUGFIX] Fix PodDisruptionBudget templates. #156
+* [BUGFIX] Fix PodDisruptionBudget templates. #157
 
 ## 0.4.1 / 2021-03-22
 

--- a/templates/alertmanager-pdb.yaml
+++ b/templates/alertmanager-pdb.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.alertmanager.podDisruptionBudget -}}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ template "cortex.fullname" . }}-alertmanager
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "cortex.name" . }}-alertmanager
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+    chart: {{ template "cortex.chart" . }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ template "cortex.name" . }}-alertmanager
+{{ toYaml .Values.alertmanager.podDisruptionBudget | indent 2 }}
+{{- end -}}

--- a/templates/compactor-pdb.yaml
+++ b/templates/compactor-pdb.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.compactor.podDisruptionBudget -}}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ template "cortex.fullname" . }}-compactor
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "cortex.name" . }}-compactor
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+    chart: {{ template "cortex.chart" . }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ template "cortex.name" . }}-compactor
+{{ toYaml .Values.compactor.podDisruptionBudget | indent 2 }}
+{{- end -}}

--- a/templates/configs-pdb.yaml
+++ b/templates/configs-pdb.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.configs.podDisruptionBudget -}}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ template "cortex.fullname" . }}-configs
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "cortex.name" . }}-configs
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+    chart: {{ template "cortex.chart" . }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ template "cortex.name" . }}-configs
+{{ toYaml .Values.configs.podDisruptionBudget | indent 2 }}
+{{- end -}}

--- a/templates/distributor-pdb.yaml
+++ b/templates/distributor-pdb.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.distributor.podDisruptionBudget -}}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ template "cortex.fullname" . }}-distributor
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "cortex.name" . }}-distributor
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+    chart: {{ template "cortex.chart" . }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ template "cortex.name" . }}-distributor
+{{ toYaml .Values.distributor.podDisruptionBudget | indent 2 }}
+{{- end -}}

--- a/templates/ingester-pdb.yaml
+++ b/templates/ingester-pdb.yaml
@@ -1,17 +1,17 @@
-{{- if .Values.podDisruptionBudget -}}
+{{- if .Values.ingester.podDisruptionBudget -}}
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
-  name: {{ template "cortex.fullname" . }}
+  name: {{ template "cortex.fullname" . }}-ingester
   namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ template "cortex.name" . }}
+    app: {{ template "cortex.name" . }}-ingester
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
     chart: {{ template "cortex.chart" . }}
 spec:
   selector:
     matchLabels:
-      app: {{ template "cortex.name" . }}
-{{ toYaml .Values.podDisruptionBudget | indent 2 }}
+      app: {{ template "cortex.name" . }}-ingester
+{{ toYaml .Values.ingester.podDisruptionBudget | indent 2 }}
 {{- end -}}

--- a/templates/nginx-pdb.yaml
+++ b/templates/nginx-pdb.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.nginx.podDisruptionBudget -}}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ template "cortex.fullname" . }}-nginx
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "cortex.name" . }}-nginx
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+    chart: {{ template "cortex.chart" . }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ template "cortex.name" . }}-nginx
+{{ toYaml .Values.nginx.podDisruptionBudget | indent 2 }}
+{{- end -}}

--- a/templates/querier-pdb.yaml
+++ b/templates/querier-pdb.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.querier.podDisruptionBudget -}}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ template "cortex.fullname" . }}-querier
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "cortex.name" . }}-querier
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+    chart: {{ template "cortex.chart" . }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ template "cortex.name" . }}-querier
+{{ toYaml .Values.querier.podDisruptionBudget | indent 2 }}
+{{- end -}}

--- a/templates/query-frontend-pdb.yaml
+++ b/templates/query-frontend-pdb.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.query_frontend.podDisruptionBudget -}}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ template "cortex.fullname" . }}-query-frontend
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "cortex.name" . }}-query-frontend
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+    chart: {{ template "cortex.chart" . }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ template "cortex.name" . }}-query-frontend
+{{ toYaml .Values.query_frontend.podDisruptionBudget | indent 2 }}
+{{- end -}}

--- a/templates/ruler-pdb.yaml
+++ b/templates/ruler-pdb.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.ruler.podDisruptionBudget -}}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ template "cortex.fullname" . }}-ruler
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "cortex.name" . }}-ruler
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+    chart: {{ template "cortex.chart" . }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ template "cortex.name" . }}-ruler
+{{ toYaml .Values.ruler.podDisruptionBudget | indent 2 }}
+{{- end -}}

--- a/templates/store-gateway-pdb.yaml
+++ b/templates/store-gateway-pdb.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.store_gateway.podDisruptionBudget -}}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ template "cortex.fullname" . }}-store-gateway
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "cortex.name" . }}-store-gateway
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+    chart: {{ template "cortex.chart" . }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ template "cortex.name" . }}-store-gateway
+{{ toYaml .Values.store_gateway.podDisruptionBudget | indent 2 }}
+{{- end -}}

--- a/templates/table-manager-pdb.yaml
+++ b/templates/table-manager-pdb.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.table_manager.podDisruptionBudget -}}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ template "cortex.fullname" . }}-table-manager
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "cortex.name" . }}-table-manager
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+    chart: {{ template "cortex.chart" . }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ template "cortex.name" . }}-table-manager
+{{ toYaml .Values.table_manager.podDisruptionBudget | indent 2 }}
+{{- end -}}


### PR DESCRIPTION
**What this PR does**:
Fixes the PodDisruptionBudget logic.

The manifest was probably created based on `target: all` mode, this PR creates a template for each component.

**Which issue(s) this PR fixes**:
Fixes #151 

**Checklist**
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`