### PR TITLE
ServiceMonitors: add options to configure metric- and relabelings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * [CHANGE] Removed dnssrvnoa resolution from block memcached (probably oversight) and moved back to simple dns resolution #164
 * [FEATURE] Support dynamic configuration of Ruler and AlertManager using sidecar #150
 * [ENHANCEMENT] Enable/Disable security & container security context #158
+* [ENHANCEMENT] ServiceMonitors: add honorLabels=true and options to configure metricRelabelings and relabelings #165
 * [BUGFIX] Fixed the default label used in pod affinity expression #162
 * [BUGFIX] Fix label and annotation overrides for services (thanks @kwangil-ha) #164
 * [BUGFIX] Fix store gateway service name regression introduced in (#144) #166

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 * [CHANGE] Removed dnssrvnoa resolution from block memcached (probably oversight) and moved back to simple dns resolution #164
 * [FEATURE] Support dynamic configuration of Ruler and AlertManager using sidecar #150
 * [ENHANCEMENT] Enable/Disable security & container security context #158
-* [ENHANCEMENT] ServiceMonitors: add honorLabels=true and options to configure metricRelabelings and relabelings #165
+* [ENHANCEMENT] ServiceMonitors: add options to configure metricRelabelings and relabelings #165
 * [BUGFIX] Fixed the default label used in pod affinity expression #162
 * [BUGFIX] Fix label and annotation overrides for services (thanks @kwangil-ha) #164
 * [BUGFIX] Fix store gateway service name regression introduced in (#144) #166

--- a/templates/alertmanager/alertmanager-servicemonitor.yaml
+++ b/templates/alertmanager/alertmanager-servicemonitor.yaml
@@ -27,7 +27,6 @@ spec:
     {{- if .Values.alertmanager.serviceMonitor.scrapeTimeout }}
     scrapeTimeout: {{ .Values.alertmanager.serviceMonitor.scrapeTimeout }}
     {{- end }}
-    honorLabels: true
     {{- if .Values.alertmanager.serviceMonitor.relabelings }}
     relabelings:
     {{- toYaml .Values.alertmanager.serviceMonitor.relabelings | nindent 4 }}

--- a/templates/alertmanager/alertmanager-servicemonitor.yaml
+++ b/templates/alertmanager/alertmanager-servicemonitor.yaml
@@ -27,4 +27,13 @@ spec:
     {{- if .Values.alertmanager.serviceMonitor.scrapeTimeout }}
     scrapeTimeout: {{ .Values.alertmanager.serviceMonitor.scrapeTimeout }}
     {{- end }}
+    honorLabels: true
+    {{- if .Values.alertmanager.serviceMonitor.relabelings }}
+    relabelings:
+    {{- toYaml .Values.alertmanager.serviceMonitor.relabelings | nindent 4 }}
+    {{- end }}
+    {{- if .Values.alertmanager.serviceMonitor.metricRelabelings }}
+    metricRelabelings:
+    {{- toYaml .Values.alertmanager.serviceMonitor.metricRelabelings | nindent 4 }}
+    {{- end }}
 {{- end }}

--- a/templates/compactor/compactor-servicemonitor.yaml
+++ b/templates/compactor/compactor-servicemonitor.yaml
@@ -27,4 +27,13 @@ spec:
     {{- if .Values.compactor.serviceMonitor.scrapeTimeout }}
     scrapeTimeout: {{ .Values.compactor.serviceMonitor.scrapeTimeout }}
     {{- end }}
+    honorLabels: true
+    {{- if .Values.compactor.serviceMonitor.relabelings }}
+    relabelings:
+    {{- toYaml .Values.compactor.serviceMonitor.relabelings | nindent 4 }}
+    {{- end }}
+    {{- if .Values.compactor.serviceMonitor.metricRelabelings }}
+    metricRelabelings:
+    {{- toYaml .Values.compactor.serviceMonitor.metricRelabelings | nindent 4 }}
+    {{- end }}
 {{- end }}

--- a/templates/compactor/compactor-servicemonitor.yaml
+++ b/templates/compactor/compactor-servicemonitor.yaml
@@ -27,7 +27,6 @@ spec:
     {{- if .Values.compactor.serviceMonitor.scrapeTimeout }}
     scrapeTimeout: {{ .Values.compactor.serviceMonitor.scrapeTimeout }}
     {{- end }}
-    honorLabels: true
     {{- if .Values.compactor.serviceMonitor.relabelings }}
     relabelings:
     {{- toYaml .Values.compactor.serviceMonitor.relabelings | nindent 4 }}

--- a/templates/configs/configs-servicemonitor.yaml
+++ b/templates/configs/configs-servicemonitor.yaml
@@ -27,7 +27,6 @@ spec:
     {{- if .Values.configs.serviceMonitor.scrapeTimeout }}
     scrapeTimeout: {{ .Values.configs.serviceMonitor.scrapeTimeout }}
     {{- end }}
-    honorLabels: true
     {{- if .Values.configs.serviceMonitor.relabelings }}
     relabelings:
     {{- toYaml .Values.configs.serviceMonitor.relabelings | nindent 4 }}

--- a/templates/configs/configs-servicemonitor.yaml
+++ b/templates/configs/configs-servicemonitor.yaml
@@ -27,4 +27,13 @@ spec:
     {{- if .Values.configs.serviceMonitor.scrapeTimeout }}
     scrapeTimeout: {{ .Values.configs.serviceMonitor.scrapeTimeout }}
     {{- end }}
+    honorLabels: true
+    {{- if .Values.configs.serviceMonitor.relabelings }}
+    relabelings:
+    {{- toYaml .Values.configs.serviceMonitor.relabelings | nindent 4 }}
+    {{- end }}
+    {{- if .Values.configs.serviceMonitor.metricRelabelings }}
+    metricRelabelings:
+    {{- toYaml .Values.configs.serviceMonitor.metricRelabelings | nindent 4 }}
+    {{- end }}
 {{- end }}

--- a/templates/distributor/distributor-servicemonitor.yaml
+++ b/templates/distributor/distributor-servicemonitor.yaml
@@ -27,4 +27,13 @@ spec:
     {{- if .Values.distributor.serviceMonitor.scrapeTimeout }}
     scrapeTimeout: {{ .Values.distributor.serviceMonitor.scrapeTimeout }}
     {{- end }}
+    honorLabels: true
+    {{- if .Values.distributor.serviceMonitor.relabelings }}
+    relabelings:
+    {{- toYaml .Values.distributor.serviceMonitor.relabelings | nindent 4 }}
+    {{- end }}
+    {{- if .Values.distributor.serviceMonitor.metricRelabelings }}
+    metricRelabelings:
+    {{- toYaml .Values.distributor.serviceMonitor.metricRelabelings | nindent 4 }}
+    {{- end }}
 {{- end }}

--- a/templates/distributor/distributor-servicemonitor.yaml
+++ b/templates/distributor/distributor-servicemonitor.yaml
@@ -27,7 +27,6 @@ spec:
     {{- if .Values.distributor.serviceMonitor.scrapeTimeout }}
     scrapeTimeout: {{ .Values.distributor.serviceMonitor.scrapeTimeout }}
     {{- end }}
-    honorLabels: true
     {{- if .Values.distributor.serviceMonitor.relabelings }}
     relabelings:
     {{- toYaml .Values.distributor.serviceMonitor.relabelings | nindent 4 }}

--- a/templates/ingester/ingester-servicemonitor.yaml
+++ b/templates/ingester/ingester-servicemonitor.yaml
@@ -27,7 +27,6 @@ spec:
     {{- if .Values.ingester.serviceMonitor.scrapeTimeout }}
     scrapeTimeout: {{ .Values.ingester.serviceMonitor.scrapeTimeout }}
     {{- end }}
-    honorLabels: true
     {{- if .Values.ingester.serviceMonitor.relabelings }}
     relabelings:
     {{- toYaml .Values.ingester.serviceMonitor.relabelings | nindent 4 }}

--- a/templates/ingester/ingester-servicemonitor.yaml
+++ b/templates/ingester/ingester-servicemonitor.yaml
@@ -27,4 +27,13 @@ spec:
     {{- if .Values.ingester.serviceMonitor.scrapeTimeout }}
     scrapeTimeout: {{ .Values.ingester.serviceMonitor.scrapeTimeout }}
     {{- end }}
+    honorLabels: true
+    {{- if .Values.ingester.serviceMonitor.relabelings }}
+    relabelings:
+    {{- toYaml .Values.ingester.serviceMonitor.relabelings | nindent 4 }}
+    {{- end }}
+    {{- if .Values.ingester.serviceMonitor.metricRelabelings }}
+    metricRelabelings:
+    {{- toYaml .Values.ingester.serviceMonitor.metricRelabelings | nindent 4 }}
+    {{- end }}
 {{- end }}

--- a/templates/querier/querier-servicemonitor.yaml
+++ b/templates/querier/querier-servicemonitor.yaml
@@ -27,7 +27,6 @@ spec:
     {{- if .Values.querier.serviceMonitor.scrapeTimeout }}
     scrapeTimeout: {{ .Values.querier.serviceMonitor.scrapeTimeout }}
     {{- end }}
-    honorLabels: true
     {{- if .Values.querier.serviceMonitor.relabelings }}
     relabelings:
     {{- toYaml .Values.querier.serviceMonitor.relabelings | nindent 4 }}

--- a/templates/querier/querier-servicemonitor.yaml
+++ b/templates/querier/querier-servicemonitor.yaml
@@ -27,4 +27,13 @@ spec:
     {{- if .Values.querier.serviceMonitor.scrapeTimeout }}
     scrapeTimeout: {{ .Values.querier.serviceMonitor.scrapeTimeout }}
     {{- end }}
+    honorLabels: true
+    {{- if .Values.querier.serviceMonitor.relabelings }}
+    relabelings:
+    {{- toYaml .Values.querier.serviceMonitor.relabelings | nindent 4 }}
+    {{- end }}
+    {{- if .Values.querier.serviceMonitor.metricRelabelings }}
+    metricRelabelings:
+    {{- toYaml .Values.querier.serviceMonitor.metricRelabelings | nindent 4 }}
+    {{- end }}
 {{- end }}

--- a/templates/query-frontend/query-frontend-servicemonitor.yaml
+++ b/templates/query-frontend/query-frontend-servicemonitor.yaml
@@ -27,7 +27,6 @@ spec:
     {{- if .Values.query_frontend.serviceMonitor.scrapeTimeout }}
     scrapeTimeout: {{ .Values.query_frontend.serviceMonitor.scrapeTimeout }}
     {{- end }}
-    honorLabels: true
     {{- if .Values.query_frontend.serviceMonitor.relabelings }}
     relabelings:
     {{- toYaml .Values.query_frontend.serviceMonitor.relabelings | nindent 4 }}

--- a/templates/query-frontend/query-frontend-servicemonitor.yaml
+++ b/templates/query-frontend/query-frontend-servicemonitor.yaml
@@ -27,4 +27,13 @@ spec:
     {{- if .Values.query_frontend.serviceMonitor.scrapeTimeout }}
     scrapeTimeout: {{ .Values.query_frontend.serviceMonitor.scrapeTimeout }}
     {{- end }}
+    honorLabels: true
+    {{- if .Values.query_frontend.serviceMonitor.relabelings }}
+    relabelings:
+    {{- toYaml .Values.query_frontend.serviceMonitor.relabelings | nindent 4 }}
+    {{- end }}
+    {{- if .Values.query_frontend.serviceMonitor.metricRelabelings }}
+    metricRelabelings:
+    {{- toYaml .Values.query_frontend.serviceMonitor.metricRelabelings | nindent 4 }}
+    {{- end }}
 {{- end }}

--- a/templates/ruler/ruler-servicemonitor.yaml
+++ b/templates/ruler/ruler-servicemonitor.yaml
@@ -27,7 +27,6 @@ spec:
     {{- if .Values.ruler.serviceMonitor.scrapeTimeout }}
     scrapeTimeout: {{ .Values.ruler.serviceMonitor.scrapeTimeout }}
     {{- end }}
-    honorLabels: true
     {{- if .Values.ruler.serviceMonitor.relabelings }}
     relabelings:
     {{- toYaml .Values.ruler.serviceMonitor.relabelings | nindent 4 }}

--- a/templates/ruler/ruler-servicemonitor.yaml
+++ b/templates/ruler/ruler-servicemonitor.yaml
@@ -27,4 +27,13 @@ spec:
     {{- if .Values.ruler.serviceMonitor.scrapeTimeout }}
     scrapeTimeout: {{ .Values.ruler.serviceMonitor.scrapeTimeout }}
     {{- end }}
+    honorLabels: true
+    {{- if .Values.ruler.serviceMonitor.relabelings }}
+    relabelings:
+    {{- toYaml .Values.ruler.serviceMonitor.relabelings | nindent 4 }}
+    {{- end }}
+    {{- if .Values.ruler.serviceMonitor.metricRelabelings }}
+    metricRelabelings:
+    {{- toYaml .Values.ruler.serviceMonitor.metricRelabelings | nindent 4 }}
+    {{- end }}
 {{- end }}

--- a/templates/store-gateway/store-gateway-servicemonitor.yaml
+++ b/templates/store-gateway/store-gateway-servicemonitor.yaml
@@ -27,4 +27,13 @@ spec:
     {{- if .Values.store_gateway.serviceMonitor.scrapeTimeout }}
     scrapeTimeout: {{ .Values.store_gateway.serviceMonitor.scrapeTimeout }}
     {{- end }}
+    honorLabels: true
+    {{- if .Values.store_gateway.serviceMonitor.relabelings }}
+    relabelings:
+    {{- toYaml .Values.store_gateway.serviceMonitor.relabelings | nindent 4 }}
+    {{- end }}
+    {{- if .Values.store_gateway.serviceMonitor.metricRelabelings }}
+    metricRelabelings:
+    {{- toYaml .Values.store_gateway.serviceMonitor.metricRelabelings | nindent 4 }}
+    {{- end }}
 {{- end }}

--- a/templates/store-gateway/store-gateway-servicemonitor.yaml
+++ b/templates/store-gateway/store-gateway-servicemonitor.yaml
@@ -27,7 +27,6 @@ spec:
     {{- if .Values.store_gateway.serviceMonitor.scrapeTimeout }}
     scrapeTimeout: {{ .Values.store_gateway.serviceMonitor.scrapeTimeout }}
     {{- end }}
-    honorLabels: true
     {{- if .Values.store_gateway.serviceMonitor.relabelings }}
     relabelings:
     {{- toYaml .Values.store_gateway.serviceMonitor.relabelings | nindent 4 }}

--- a/templates/table-manager/table-manager-servicemonitor.yaml
+++ b/templates/table-manager/table-manager-servicemonitor.yaml
@@ -27,4 +27,13 @@ spec:
     {{- if .Values.table_manager.serviceMonitor.scrapeTimeout }}
     scrapeTimeout: {{ .Values.table_manager.serviceMonitor.scrapeTimeout }}
     {{- end }}
+    honorLabels: true
+    {{- if .Values.table_manager.serviceMonitor.relabelings }}
+    relabelings:
+    {{- toYaml .Values.table_manager.serviceMonitor.relabelings | nindent 4 }}
+    {{- end }}
+    {{- if .Values.table_manager.serviceMonitor.metricRelabelings }}
+    metricRelabelings:
+    {{- toYaml .Values.table_manager.serviceMonitor.metricRelabelings | nindent 4 }}
+    {{- end }}
 {{- end }}

--- a/templates/table-manager/table-manager-servicemonitor.yaml
+++ b/templates/table-manager/table-manager-servicemonitor.yaml
@@ -27,7 +27,6 @@ spec:
     {{- if .Values.table_manager.serviceMonitor.scrapeTimeout }}
     scrapeTimeout: {{ .Values.table_manager.serviceMonitor.scrapeTimeout }}
     {{- end }}
-    honorLabels: true
     {{- if .Values.table_manager.serviceMonitor.relabelings }}
     relabelings:
     {{- toYaml .Values.table_manager.serviceMonitor.relabelings | nindent 4 }}

--- a/values.yaml
+++ b/values.yaml
@@ -184,6 +184,8 @@ alertmanager:
   serviceMonitor:
     enabled: false
     additionalLabels: {}
+    relabelings: []
+    metricRelabelings: []
 
   resources: {}
   #  limits:
@@ -372,6 +374,8 @@ distributor:
   serviceMonitor:
     enabled: false
     additionalLabels: {}
+    relabelings: []
+    metricRelabelings: []
 
   resources: {}
   #  limits:
@@ -466,6 +470,8 @@ ingester:
   serviceMonitor:
     enabled: false
     additionalLabels: {}
+    relabelings: []
+    metricRelabelings: []
 
   resources: {}
   #  limits:
@@ -600,6 +606,8 @@ ruler:
   serviceMonitor:
     enabled: false
     additionalLabels: {}
+    relabelings: []
+    metricRelabelings: []
 
   resources: {}
   #  limits:
@@ -734,6 +742,8 @@ querier:
   serviceMonitor:
     enabled: false
     additionalLabels: {}
+    relabelings: []
+    metricRelabelings: []
 
   resources: {}
   #  limits:
@@ -822,6 +832,8 @@ query_frontend:
   serviceMonitor:
     enabled: false
     additionalLabels: {}
+    relabelings: []
+    metricRelabelings: []
 
   resources: {}
   #  limits:
@@ -909,6 +921,8 @@ table_manager:
   serviceMonitor:
     enabled: false
     additionalLabels: {}
+    relabelings: []
+    metricRelabelings: []
 
   resources: {}
   #  limits:
@@ -986,6 +1000,8 @@ configs:
   serviceMonitor:
     enabled: false
     additionalLabels: {}
+    relabelings: []
+    metricRelabelings: []
 
   resources: {}
   #  limits:
@@ -1075,6 +1091,8 @@ nginx:
   serviceMonitor:
     enabled: false
     additionalLabels: {}
+    relabelings: []
+    metricRelabelings: []
 
   resources: {}
   #  limits:
@@ -1151,6 +1169,8 @@ store_gateway:
   serviceMonitor:
     enabled: false
     additionalLabels: {}
+    relabelings: []
+    metricRelabelings: []
 
   resources: {}
   #  limits:
@@ -1275,6 +1295,8 @@ compactor:
   serviceMonitor:
     enabled: false
     additionalLabels: {}
+    relabelings: []
+    metricRelabelings: []
 
   resources: {}
   #  limits:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
3. Please do not edit/bump the Chart.yaml "version" field
-->

**What this PR does**:
Allows you to use the ServiceMonitor's metricRelabelings and relabelings configuration via helm values. For example:
```YAML
  serviceMonitor:
    enabled: true
    relabelings:
      - sourceLabels: [__meta_kubernetes_service_label_cluster]
        regex: (.*)
        replacement: $1
        targetLabel: cluster
        action: replace
```

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`