### PR TITLE
fix store gateway service name regression introduced in #144

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 * [ENHANCEMENT] Enable/Disable security & container security context #158
 * [BUGFIX] Fixed the default label used in pod affinity expression #162
 * [BUGFIX] Fix label and annotation overrides for services (thanks @kwangil-ha) #164
-* [BUGFIX] Fix store gateway service name regression introduced in #144
+* [BUGFIX] Fix store gateway service name regression introduced in (#144) #166
 
 ## 0.5.0 / 2021-06-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * [ENHANCEMENT] Enable/Disable security & container security context #158
 * [BUGFIX] Fixed the default label used in pod affinity expression #162
 * [BUGFIX] Fix label and annotation overrides for services (thanks @kwangil-ha) #164
+* [BUGFIX] Fix store gateway service name regression introduced in #144
 
 ## 0.5.0 / 2021-06-08
 

--- a/templates/store-gateway/store-gateway-svc-headless.yaml
+++ b/templates/store-gateway/store-gateway-svc-headless.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "cortex.storeGatewayFullname" . }}
+  name: {{ include "cortex.storeGatewayFullname" . }}-headless
   labels:
     {{- include "cortex.storeGatewayLabels" . | nindent 4 }}
     {{- with .Values.store_gateway.service.labels }}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
3. Please do not edit/bump the Chart.yaml "version" field
-->

**What this PR does**:
Renames store-gateway-svc.yaml to store-gateway-svc-headless.yaml and fixxes the kubernetes service name.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`