### PR TITLE
Fix memcached args for querier-frontend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * [BUGFIX] Fixed the default label used in pod affinity expression #162
 * [BUGFIX] Fix label and annotation overrides for services (thanks @kwangil-ha) #164
 * [BUGFIX] Fix store gateway service name regression introduced in (#144) #166
+* [BUGFIX] Fix querier-frontend memcached arg #170
 
 ## 0.5.0 / 2021-06-08
 

--- a/templates/query-frontend/query-frontend-dep.yaml
+++ b/templates/query-frontend/query-frontend-dep.yaml
@@ -52,7 +52,7 @@ spec:
           args:
             - "-target=query-frontend"
             - "-config.file=/etc/cortex/cortex.yaml"
-            {{- include "cortex.memcached" . | nindent 12 }}
+            {{- include "cortex.frontend-memcached" . | nindent 12 }}
           {{- range $key, $value := .Values.query_frontend.extraArgs }}
             - "-{{ $key }}={{ $value }}"
           {{- end }}


### PR DESCRIPTION

**What this PR does**:
in querier-frontend the wrong memcached args have been included 

**Which issue(s) this PR fixes**:
Fixes #170
