### PR TITLE
Fix wrong memcached addresses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master / unreleased
 
+* [ENHANCEMENT] Use FQDN for memcached addresses #175
+
 ## 0.6.0 / 2021-06-28
 
 * [CHANGE] Removed dnssrvnoa resolution from block memcached (probably oversight) and moved back to simple dns resolution #164

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -87,20 +87,20 @@ Create configuration parameters for memcached configuration
 {{- define "cortex.memcached" -}}
 {{- if and (eq .Values.config.storage.engine "blocks") (index .Values "tags" "blocks-storage-memcached") }}
 - "-blocks-storage.bucket-store.index-cache.backend=memcached"
-- "-blocks-storage.bucket-store.index-cache.memcached.addresses=dns+{{ .Release.Name }}-memcached-blocks-index.{{ .Release.Namespace }}.svc:11211"
+- "-blocks-storage.bucket-store.index-cache.memcached.addresses=dns+{{ .Release.Name }}-memcached-blocks-index.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:11211"
 - "-blocks-storage.bucket-store.chunks-cache.backend=memcached"
-- "-blocks-storage.bucket-store.chunks-cache.memcached.addresses=dns+{{ .Release.Name }}-memcached-blocks.{{ .Release.Namespace }}.svc:11211"
+- "-blocks-storage.bucket-store.chunks-cache.memcached.addresses=dns+{{ .Release.Name }}-memcached-blocks.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:11211"
 - "-blocks-storage.bucket-store.metadata-cache.backend=memcached"
-- "-blocks-storage.bucket-store.metadata-cache.memcached.addresses=dns+{{ .Release.Name }}-memcached-blocks-metadata.{{ .Release.Namespace }}.svc:11211"
+- "-blocks-storage.bucket-store.metadata-cache.memcached.addresses=dns+{{ .Release.Name }}-memcached-blocks-metadata.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:11211"
 {{- end -}}
 {{- if and (ne .Values.config.storage.engine "blocks") .Values.memcached.enabled }}
-- -store.chunks-cache.memcached.addresses=dns+{{ .Release.Name }}-memcached.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:11211
+- "-store.chunks-cache.memcached.addresses=dns+{{ .Release.Name }}-memcached.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:11211"
 {{- end -}}
 {{- if and (ne .Values.config.storage.engine "blocks") (index .Values "memcached-index-read" "enabled") }}
-- -store.index-cache-read.memcached.addresses=dns+{{ .Release.Name }}-memcached-index-read.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:11211
+- "-store.index-cache-read.memcached.addresses=dns+{{ .Release.Name }}-memcached-index-read.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:11211"
 {{- end -}}
 {{- if and (ne .Values.config.storage.engine "blocks") (index .Values "memcached-index-write" "enabled") }}
-- -store.index-cache-write.memcached.addresses=dns+{{ .Release.Name }}-memcached-index-write.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:11211
+- "-store.index-cache-write.memcached.addresses=dns+{{ .Release.Name }}-memcached-index-write.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:11211"
 {{- end -}}
 {{- end -}}
 


### PR DESCRIPTION

**What this PR does**:
This fixes the following Error I got on my store-gateway with the latest helm chart (0.6.0)
```
name=metadata-cache msg="failed to resolve addresses for memcached" addresses=dns+cortex-memcached-blocks-metadata.cortex.svc:11211 err="lookup IP addresses \"cortex-memcached-blocks-metadata.cortex.svc\": i/o timeout"
```

The issue is that `cortex-memcached-blocks-metadata.cortex.svc` doesn't work. Either just use the service name (when its in the same namespace) so `cortex-memcached-blocks-metadata` or use the full svc dns record which would be `cortex-memcached-blocks-metadata.cortex.svc.cluster.local`.

```bash
/ # nslookup cortex-memcached-blocks.cortex.svc
Server:		172.20.0.10
Address:	172.20.0.10:53

** server can't find cortex-memcached-blocks.cortex.svc: NXDOMAIN

** server can't find cortex-memcached-blocks.cortex.svc: NXDOMAIN
```
```
/ # nslookup cortex-memcached-blocks.cortex.svc.cluster.local
Server:		172.20.0.10
Address:	172.20.0.10:53

*** Can't find cortex-memcached-blocks.cortex.svc.cluster.local: No answer

Name:	cortex-memcached-blocks.cortex.svc.cluster.local
Address: 10.5.12.79
Name:	cortex-memcached-blocks.cortex.svc.cluster.local
Address: 10.5.26.70

```

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`