### PR TITLE
add autoscaler for ingesters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## master / unreleased
 
+* [FEATURE] Add autoscaler for ingesters #182
 * [ENHANCEMENT] Use FQDN for memcached addresses #175
 
 ## 0.6.0 / 2021-06-28

--- a/README.md
+++ b/README.md
@@ -458,6 +458,12 @@ Kubernetes: `^1.19.0-0`
 | ingester.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].podAffinityTerm.topologyKey | string | `"kubernetes.io/hostname"` |  |
 | ingester.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].weight | int | `100` |  |
 | ingester.annotations | object | `{}` |  |
+| ingester.autoscaling.behavior.scaleDown.selectPolicy | string | `"Disabled"` | Scaledown procedure varies, so automatic scaledown is disabled Ref: https://cortexmetrics.io/docs/guides/ingesters-scaling-up-and-down/#scaling-down |
+| ingester.autoscaling.behavior.scaleUp.policies | list | `[{"periodSeconds":1800,"type":"Pods","value":1}]` | This default scaleup policy allows adding 1 pod every 30 minutes. Ref: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#support-for-configurable-scaling-behavior |
+| ingester.autoscaling.enabled | bool | `false` |  |
+| ingester.autoscaling.maxReplicas | int | `30` |  |
+| ingester.autoscaling.minReplicas | int | `3` |  |
+| ingester.autoscaling.targetMemoryUtilizationPercentage | int | `80` |  |
 | ingester.containerSecurityContext.enabled | bool | `true` |  |
 | ingester.containerSecurityContext.readOnlyRootFilesystem | bool | `true` |  |
 | ingester.env | list | `[]` |  |

--- a/templates/ingester/ingester-dep.yaml
+++ b/templates/ingester/ingester-dep.yaml
@@ -9,7 +9,9 @@ metadata:
   annotations:
     {{- toYaml .Values.ingester.annotations | nindent 4 }}
 spec:
+  {{- if not .Values.ingester.autoscaling.enabled }}
   replicas: {{ .Values.ingester.replicas }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "cortex.ingesterSelectorLabels" . | nindent 6 }}

--- a/templates/ingester/ingester-hpa.yaml
+++ b/templates/ingester/ingester-hpa.yaml
@@ -1,0 +1,29 @@
+{{- with .Values.ingester.autoscaling -}}
+{{- if .enabled }}
+apiVersion: autoscaling/v2beta2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "cortex.ingesterFullname" $ }}
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    {{- include "cortex.ingesterLabels" $ | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: {{ if $.Values.ingester.statefulSet.enabled }}StatefulSet{{ else }}Deployment{{ end }}
+    name: {{ include "cortex.ingesterFullname" $ }}
+  minReplicas: {{ .minReplicas }}
+  maxReplicas: {{ .maxReplicas }}
+  metrics:
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .targetMemoryUtilizationPercentage }}
+  {{- with .behavior }}
+  behavior:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/templates/ingester/ingester-statefulset.yaml
+++ b/templates/ingester/ingester-statefulset.yaml
@@ -9,7 +9,9 @@ metadata:
   annotations:
     {{- toYaml .Values.ingester.annotations | nindent 4 }}
 spec:
+  {{- if not .Values.ingester.autoscaling.enabled }}
   replicas: {{ .Values.ingester.replicas }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "cortex.ingesterSelectorLabels" . | nindent 6 }}

--- a/values.yaml
+++ b/values.yaml
@@ -511,6 +511,24 @@ ingester:
 
   annotations: {}
 
+  autoscaling:
+    enabled: false
+    minReplicas: 3
+    maxReplicas: 30
+    targetMemoryUtilizationPercentage: 80
+    behavior:
+      scaleDown:
+        # -- Scaledown procedure varies, so automatic scaledown is disabled
+        # Ref: https://cortexmetrics.io/docs/guides/ingesters-scaling-up-and-down/#scaling-down
+        selectPolicy: Disabled
+      scaleUp:
+        # -- This default scaleup policy allows adding 1 pod every 30 minutes.
+        # Ref: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#support-for-configurable-scaling-behavior
+        policies:
+          - type: Pods
+            value: 1
+            periodSeconds: 1800
+
   ## DEPRECATED: use persistentVolume.subPath instead
   persistence:
     subPath:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
3. Please do not edit/bump the Chart.yaml "version" field
-->

**What this PR does**:
Adds a `HorizontalPodAutoscaler` for the ingesters.

https://cortexmetrics.io/docs/guides/capacity-planning/ describes that ingester memory grows as series are added, so this autoscaler tracks memory usage to make scaling decisions.

https://cortexmetrics.io/docs/guides/ingesters-scaling-up-and-down/#scaling-down says that "adding more ingesters to a Cortex cluster is considered a safe operation", so this autoscaler behavior is configured to allow adding one ingester pod at a time, but does not automatically scale down.

**Checklist**
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`