### PR TITLE
define namespace in templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## master / unreleased
 
 * [FEATURE] Add autoscaler for ingesters #182
+* [ENHANCEMENT] Define namespace in templates #184
 * [ENHANCEMENT] Use FQDN for memcached addresses #175
 
 ## 0.6.0 / 2021-06-28

--- a/templates/alertmanager/alertmanager-dep.yaml
+++ b/templates/alertmanager/alertmanager-dep.yaml
@@ -4,6 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "cortex.alertmanagerFullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "cortex.alertmanagerLabels" . | nindent 4 }}
     app.kubernetes.io/part-of: memberlist

--- a/templates/alertmanager/alertmanager-poddisruptionbudget.yaml
+++ b/templates/alertmanager/alertmanager-poddisruptionbudget.yaml
@@ -3,6 +3,7 @@ apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "cortex.alertmanagerFullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "cortex.alertmanagerLabels" . | nindent 4 }}
 spec:

--- a/templates/alertmanager/alertmanager-servicemonitor.yaml
+++ b/templates/alertmanager/alertmanager-servicemonitor.yaml
@@ -3,6 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "cortex.alertmanagerFullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "cortex.alertmanagerLabels" . | nindent 4 }}
     {{- if .Values.alertmanager.serviceMonitor.additionalLabels }}

--- a/templates/alertmanager/alertmanager-statefulset.yaml
+++ b/templates/alertmanager/alertmanager-statefulset.yaml
@@ -5,6 +5,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ include "cortex.alertmanagerFullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "cortex.alertmanagerLabels" . | nindent 4 }}
     app.kubernetes.io/part-of: memberlist

--- a/templates/alertmanager/alertmanager-svc-headless.yaml
+++ b/templates/alertmanager/alertmanager-svc-headless.yaml
@@ -5,6 +5,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "cortex.alertmanagerFullname" . }}-headless
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "cortex.alertmanagerLabels" . | nindent 4 }}
     {{- with .Values.alertmanager.service.labels }}

--- a/templates/alertmanager/alertmanager-svc.yaml
+++ b/templates/alertmanager/alertmanager-svc.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "cortex.alertmanagerFullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "cortex.alertmanagerLabels" . | nindent 4 }}
     {{- with .Values.alertmanager.service.labels }}

--- a/templates/compactor/compactor-poddisruptionbudget.yaml
+++ b/templates/compactor/compactor-poddisruptionbudget.yaml
@@ -3,6 +3,7 @@ apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "cortex.compactorFullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "cortex.compactorLabels" . | nindent 4 }}
 spec:

--- a/templates/compactor/compactor-servicemonitor.yaml
+++ b/templates/compactor/compactor-servicemonitor.yaml
@@ -3,6 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "cortex.compactorFullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "cortex.compactorLabels" . | nindent 4 }}
     {{- if .Values.compactor.serviceMonitor.additionalLabels }}

--- a/templates/compactor/compactor-statefulset.yaml
+++ b/templates/compactor/compactor-statefulset.yaml
@@ -4,6 +4,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ include "cortex.compactorFullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "cortex.compactorLabels" . | nindent 4 }}
     app.kubernetes.io/part-of: memberlist

--- a/templates/compactor/compactor-svc.yaml
+++ b/templates/compactor/compactor-svc.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "cortex.compactorFullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "cortex.compactorLabels" . | nindent 4 }}
     {{- with .Values.compactor.service.labels }}

--- a/templates/configs/configs-dep.yaml
+++ b/templates/configs/configs-dep.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "cortex.configsFullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "cortex.configsLabels" . | nindent 4 }}
   annotations:

--- a/templates/configs/configs-poddisruptionbudget.yaml
+++ b/templates/configs/configs-poddisruptionbudget.yaml
@@ -3,6 +3,7 @@ apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "cortex.configsFullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "cortex.configsLabels" . | nindent 4 }}
 spec:

--- a/templates/configs/configs-servicemonitor.yaml
+++ b/templates/configs/configs-servicemonitor.yaml
@@ -3,6 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "cortex.configsFullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "cortex.configsLabels" . | nindent 4 }}
     {{- if .Values.configs.serviceMonitor.additionalLabels }}

--- a/templates/configs/configs-svc.yaml
+++ b/templates/configs/configs-svc.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "cortex.configsFullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "cortex.configsLabels" . | nindent 4 }}
     {{- with .Values.configs.service.labels }}

--- a/templates/distributor/distributor-dep.yaml
+++ b/templates/distributor/distributor-dep.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "cortex.distributorFullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "cortex.distributorLabels" . | nindent 4 }}
     app.kubernetes.io/part-of: memberlist

--- a/templates/distributor/distributor-poddisruptionbudget.yaml
+++ b/templates/distributor/distributor-poddisruptionbudget.yaml
@@ -3,6 +3,7 @@ apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "cortex.distributorFullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "cortex.distributorLabels" . | nindent 4 }}
 spec:

--- a/templates/distributor/distributor-servicemonitor.yaml
+++ b/templates/distributor/distributor-servicemonitor.yaml
@@ -3,6 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "cortex.distributorFullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "cortex.distributorLabels" . | nindent 4 }}
     {{- if .Values.distributor.serviceMonitor.additionalLabels }}

--- a/templates/distributor/distributor-svc-headless.yaml
+++ b/templates/distributor/distributor-svc-headless.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "cortex.distributorFullname" . }}-headless
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "cortex.distributorLabels" . | nindent 4 }}
     {{- with .Values.distributor.service.labels }}

--- a/templates/distributor/distributor-svc.yaml
+++ b/templates/distributor/distributor-svc.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "cortex.distributorFullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "cortex.distributorLabels" . | nindent 4 }}
     {{- with .Values.distributor.service.labels }}

--- a/templates/ingester/ingester-dep.yaml
+++ b/templates/ingester/ingester-dep.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "cortex.ingesterFullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "cortex.ingesterLabels" . | nindent 4 }}
     app.kubernetes.io/part-of: memberlist

--- a/templates/ingester/ingester-poddisruptionbudget.yaml
+++ b/templates/ingester/ingester-poddisruptionbudget.yaml
@@ -3,6 +3,7 @@ apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "cortex.ingesterFullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "cortex.ingesterLabels" . | nindent 4 }}
 spec:

--- a/templates/ingester/ingester-servicemonitor.yaml
+++ b/templates/ingester/ingester-servicemonitor.yaml
@@ -3,6 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "cortex.ingesterFullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "cortex.ingesterLabels" . | nindent 4 }}
     {{- if .Values.ingester.serviceMonitor.additionalLabels }}

--- a/templates/ingester/ingester-statefulset.yaml
+++ b/templates/ingester/ingester-statefulset.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ include "cortex.ingesterFullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "cortex.ingesterLabels" . | nindent 4 }}
     app.kubernetes.io/part-of: memberlist

--- a/templates/ingester/ingester-svc-headless.yaml
+++ b/templates/ingester/ingester-svc-headless.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "cortex.ingesterFullname" . }}-headless
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "cortex.ingesterLabels" . | nindent 4 }}
     {{- with .Values.ingester.service.labels }}

--- a/templates/ingester/ingester-svc.yaml
+++ b/templates/ingester/ingester-svc.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "cortex.ingesterFullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "cortex.ingesterLabels" . | nindent 4 }}
     {{- with .Values.ingester.service.labels }}

--- a/templates/nginx/nginx-config.yaml
+++ b/templates/nginx/nginx-config.yaml
@@ -3,6 +3,7 @@ kind: ConfigMap
 apiVersion: v1
 metadata:
   name: {{ include "cortex.nginxFullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "cortex.nginxLabels" . | nindent 4 }}
 data:

--- a/templates/nginx/nginx-dep.yaml
+++ b/templates/nginx/nginx-dep.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "cortex.nginxFullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "cortex.nginxLabels" . | nindent 4 }}
   annotations:

--- a/templates/nginx/nginx-ingress.yaml
+++ b/templates/nginx/nginx-ingress.yaml
@@ -3,6 +3,7 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ include "cortex.nginxFullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "cortex.nginxLabels" . | nindent 4 }}
   annotations:

--- a/templates/nginx/nginx-poddisruptionbudget.yaml
+++ b/templates/nginx/nginx-poddisruptionbudget.yaml
@@ -3,6 +3,7 @@ apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "cortex.nginxFullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "cortex.nginxLabels" . | nindent 4 }}
 spec:

--- a/templates/nginx/nginx-svc.yaml
+++ b/templates/nginx/nginx-svc.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "cortex.nginxFullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "cortex.nginxLabels" . | nindent 4 }}
     {{- with .Values.nginx.service.labels }}

--- a/templates/querier/querier-dep.yaml
+++ b/templates/querier/querier-dep.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "cortex.querierFullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "cortex.querierLabels" . | nindent 4 }}
   annotations:

--- a/templates/querier/querier-poddisruptionbudget.yaml
+++ b/templates/querier/querier-poddisruptionbudget.yaml
@@ -3,6 +3,7 @@ apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "cortex.querierFullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "cortex.querierLabels" . | nindent 4 }}
 spec:

--- a/templates/querier/querier-servicemonitor.yaml
+++ b/templates/querier/querier-servicemonitor.yaml
@@ -3,6 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "cortex.querierFullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "cortex.querierLabels" . | nindent 4 }}
     {{- if .Values.querier.serviceMonitor.additionalLabels }}

--- a/templates/querier/querier-svc.yaml
+++ b/templates/querier/querier-svc.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "cortex.querierFullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "cortex.querierLabels" . | nindent 4 }}
     {{- with .Values.querier.service.labels }}

--- a/templates/query-frontend/query-frontend-dep.yaml
+++ b/templates/query-frontend/query-frontend-dep.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "cortex.queryFrontendFullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "cortex.queryFrontendLabels" . | nindent 4 }}
   annotations:

--- a/templates/query-frontend/query-frontend-servicemonitor.yaml
+++ b/templates/query-frontend/query-frontend-servicemonitor.yaml
@@ -3,6 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "cortex.queryFrontendFullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "cortex.queryFrontendLabels" . | nindent 4 }}
     {{- if .Values.query_frontend.serviceMonitor.additionalLabels }}

--- a/templates/query-frontend/query-frontend-svc-headless.yaml
+++ b/templates/query-frontend/query-frontend-svc-headless.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "cortex.queryFrontendFullname" . }}-headless
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "cortex.queryFrontendLabels" . | nindent 4 }}
     {{- with .Values.query_frontend.service.labels }}

--- a/templates/query-frontend/query-frontend-svc.yaml
+++ b/templates/query-frontend/query-frontend-svc.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "cortex.queryFrontendFullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "cortex.queryFrontendLabels" . | nindent 4 }}
     {{- with .Values.query_frontend.service.labels }}

--- a/templates/query-frontend/query-poddisruptionbudget.yaml
+++ b/templates/query-frontend/query-poddisruptionbudget.yaml
@@ -3,6 +3,7 @@ apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "cortex.queryFrontendFullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "cortex.queryFrontendLabels" . | nindent 4 }}
 spec:

--- a/templates/ruler/ruler-configmap.yaml
+++ b/templates/ruler/ruler-configmap.yaml
@@ -5,6 +5,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "cortex.rulerFullname" $ }}-{{ include "cortex.rulerRulesDirName" $dir }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "cortex.rulerLabels" $ | nindent 4 }}
 data:

--- a/templates/ruler/ruler-dep.yaml
+++ b/templates/ruler/ruler-dep.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "cortex.rulerFullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "cortex.rulerLabels" . | nindent 4 }}
     app.kubernetes.io/part-of: memberlist

--- a/templates/ruler/ruler-poddisruptionbudget.yaml
+++ b/templates/ruler/ruler-poddisruptionbudget.yaml
@@ -3,6 +3,7 @@ apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "cortex.rulerFullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "cortex.rulerLabels" . | nindent 4 }}
 spec:

--- a/templates/ruler/ruler-servicemonitor.yaml
+++ b/templates/ruler/ruler-servicemonitor.yaml
@@ -3,6 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "cortex.rulerFullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "cortex.rulerLabels" . | nindent 4 }}
     {{- if .Values.ruler.serviceMonitor.additionalLabels }}

--- a/templates/ruler/ruler-svc.yaml
+++ b/templates/ruler/ruler-svc.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "cortex.rulerFullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "cortex.rulerLabels" . | nindent 4 }}
     {{- with .Values.ruler.service.labels }}

--- a/templates/secret-postgresql.yaml
+++ b/templates/secret-postgresql.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ template "cortex.fullname" . }}-postgresql
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "cortex.labels" . | nindent 4 }}
 data:

--- a/templates/secret.yaml
+++ b/templates/secret.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ template "cortex.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "cortex.labels" . | nindent 4 }}
 data:

--- a/templates/serviceaccount.yaml
+++ b/templates/serviceaccount.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "cortex.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "cortex.labels" . | nindent 4 }}
   annotations:

--- a/templates/store-gateway/store-gateway-poddisruptionbudget.yaml
+++ b/templates/store-gateway/store-gateway-poddisruptionbudget.yaml
@@ -3,6 +3,7 @@ apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "cortex.storeGatewayFullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "cortex.storeGatewayLabels" . | nindent 4 }}
 spec:

--- a/templates/store-gateway/store-gateway-servicemonitor.yaml
+++ b/templates/store-gateway/store-gateway-servicemonitor.yaml
@@ -3,6 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "cortex.storeGatewayFullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "cortex.storeGatewayLabels" . | nindent 4 }}
     {{- if .Values.store_gateway.serviceMonitor.additionalLabels }}

--- a/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/templates/store-gateway/store-gateway-statefulset.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ include "cortex.storeGatewayFullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "cortex.storeGatewayLabels" . | nindent 4 }}
     app.kubernetes.io/part-of: memberlist

--- a/templates/store-gateway/store-gateway-svc-headless.yaml
+++ b/templates/store-gateway/store-gateway-svc-headless.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "cortex.storeGatewayFullname" . }}-headless
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "cortex.storeGatewayLabels" . | nindent 4 }}
     {{- with .Values.store_gateway.service.labels }}

--- a/templates/store-gateway/store-gateway-svc.yaml
+++ b/templates/store-gateway/store-gateway-svc.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "cortex.storeGatewayFullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "cortex.storeGatewayLabels" . | nindent 4 }}
     {{- with .Values.store_gateway.service.labels }}

--- a/templates/svc-memberlist-headless.yaml
+++ b/templates/svc-memberlist-headless.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "cortex.fullname" . }}-memberlist
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "cortex.labels" . | nindent 4 }}
 spec:

--- a/templates/table-manager/table-manager-dep.yaml
+++ b/templates/table-manager/table-manager-dep.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "cortex.tableManagerFullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "cortex.tableManagerLabels" . | nindent 4 }}
   annotations:

--- a/templates/table-manager/table-manager-poddisruptionbudget.yaml
+++ b/templates/table-manager/table-manager-poddisruptionbudget.yaml
@@ -3,6 +3,7 @@ apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "cortex.tableManagerFullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "cortex.tableManagerLabels" . | nindent 4 }}
 spec:

--- a/templates/table-manager/table-manager-servicemonitor.yaml
+++ b/templates/table-manager/table-manager-servicemonitor.yaml
@@ -3,6 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "cortex.tableManagerFullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "cortex.tableManagerLabels" . | nindent 4 }}
     {{- if .Values.table_manager.serviceMonitor.additionalLabels }}

--- a/templates/table-manager/table-manager-svc.yaml
+++ b/templates/table-manager/table-manager-svc.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "cortex.tableManagerFullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "cortex.tableManagerLabels" . | nindent 4 }}
     {{- with .Values.table_manager.service.labels }}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
3. Please do not edit/bump the Chart.yaml "version" field
-->

**What this PR does**:
This explicitly sets `.metadata.namespace` on resources based on the value supplied with `helm --namespace`. This is useful when deploying with tools that separate the render and deploy steps rather than use a simple `helm install ...`. Consider the simple example `helm template --namespace ... | kubectl apply -f -`; in this case all the cortex resources are deployed to the default namespace unless the template explicitly defines `.metadata.namespace`. A more complex variation of this example might archive the rendered manifest, and for auditing purposes it's helpful to have the namespace defined.
```
helm template --namespace ... > manifest.yaml
archive manifest.yaml
kubectl apply -f manifest.yaml
```

**Checklist**
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`