### PR TITLE
add workflow to generate README.md

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -2,9 +2,14 @@ name: Lint and Test Charts
 
 on:
   push:
-    branches:
+    branches-ignore:
+      - master
       - main
   pull_request:
+    paths-ignore:
+      - '*.md'
+      - 'docs/**'
+      - 'tools/**'
 
 jobs:
   lint-test:
@@ -34,11 +39,6 @@ jobs:
 
       - name: Run chart-testing (lint)
         run: ct lint --config ct.yaml
-
-      - name: Updated README.md
-        run: |
-          make README.md
-          git diff --exit-code -- README.md
 
       - name: Create kind cluster
         uses: helm/kind-action@v1.2.0

--- a/.github/workflows/readme.yml
+++ b/.github/workflows/readme.yml
@@ -1,0 +1,30 @@
+name: Generate README.md
+
+on:
+  push:
+    branches-ignore:
+      - main
+      - master
+    paths:
+      - values.yaml
+
+jobs:
+  generate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Generate README.md
+        run: |
+          make README.md
+
+      - name: Commit changes
+        uses: EndBug/add-and-commit@v7
+        with:
+          add: README.md
+          default_author: github_actions
+          message: "[skip ci] generate README.md"
+          signoff: true


### PR DESCRIPTION
**What this PR does**:
This adds a Github Action workflow to automate running `make` (`helm-docs`) on each PR and committing any changes.

This is a continuation of the work in #183.

Github Actions workflows will not trigger on commits pushed by Github Actions (differentiated by the auto auth token), so this workflow will cause the Lint and Test workflow to not run. Since that is a required workflow, the PR cannot be merged until Lint and Test is triggered some other way, like closing and reopening the PR. I've left this PR in draft mode while we try to find the best solution to automate running `make` without defeating the required PR status checks.

**Which issue(s) this PR fixes**:
Fixes #187