### PR TITLE
add autoscaler for distributors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## master / unreleased
 
+* [FEATURE] Add autoscaler for distributors #189
 * [FEATURE] Add autoscaler for ingesters #182
 * [ENHANCEMENT] Define namespace in templates #184
 * [ENHANCEMENT] Use FQDN for memcached addresses #175

--- a/README.md
+++ b/README.md
@@ -413,6 +413,12 @@ Kubernetes: `^1.19.0-0`
 | distributor.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].podAffinityTerm.topologyKey | string | `"kubernetes.io/hostname"` |  |
 | distributor.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].weight | int | `100` |  |
 | distributor.annotations | object | `{}` |  |
+| distributor.autoscaling.behavior | object | `{}` | Ref: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#support-for-configurable-scaling-behavior |
+| distributor.autoscaling.enabled | bool | `false` | Creates a HorizontalPodAutoscaler for the distributor pods. |
+| distributor.autoscaling.maxReplicas | int | `30` |  |
+| distributor.autoscaling.minReplicas | int | `2` |  |
+| distributor.autoscaling.targetCPUUtilizationPercentage | int | `80` |  |
+| distributor.autoscaling.targetMemoryUtilizationPercentage | int | `0` |  |
 | distributor.containerSecurityContext.enabled | bool | `true` |  |
 | distributor.containerSecurityContext.readOnlyRootFilesystem | bool | `true` |  |
 | distributor.env | list | `[]` |  |

--- a/ci/test-values.yaml
+++ b/ci/test-values.yaml
@@ -57,9 +57,15 @@ config:
 
 ingester:
   replicas: 1
+  autoscaling:
+    enabled: true
+    minReplicas: 1
   statefulSet:
     enabled: true
 distributor:
   replicas: 1
+  autoscaling:
+    enabled: true
+    minReplicas: 1
 nginx:
   replicas: 1

--- a/templates/distributor/distributor-dep.yaml
+++ b/templates/distributor/distributor-dep.yaml
@@ -9,7 +9,9 @@ metadata:
   annotations:
     {{- toYaml .Values.distributor.annotations | nindent 4 }}
 spec:
+  {{- if not .Values.distributor.autoscaling.enabled }}
   replicas: {{ .Values.distributor.replicas }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "cortex.distributorSelectorLabels" . | nindent 6 }}

--- a/templates/distributor/distributor-hpa.yaml
+++ b/templates/distributor/distributor-hpa.yaml
@@ -1,0 +1,39 @@
+{{- with .Values.distributor.autoscaling -}}
+{{- if .enabled }}
+apiVersion: autoscaling/v2beta2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "cortex.distributorFullname" $ }}
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    {{- include "cortex.distributorLabels" $ | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "cortex.distributorFullname" $ }}
+  minReplicas: {{ .minReplicas }}
+  maxReplicas: {{ .maxReplicas }}
+  metrics:
+  {{- with .targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ . }}
+  {{- end }}
+  {{- with .targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ . }}
+  {{- end }}
+  {{- with .behavior }}
+  behavior:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -422,6 +422,17 @@ distributor:
             topologyKey: 'kubernetes.io/hostname'
 
   annotations: {}
+
+  autoscaling:
+    # -- Creates a HorizontalPodAutoscaler for the distributor pods.
+    enabled: false
+    minReplicas: 2
+    maxReplicas: 30
+    targetCPUUtilizationPercentage: 80
+    targetMemoryUtilizationPercentage: 0  # 80
+    # -- Ref: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#support-for-configurable-scaling-behavior
+    behavior: {}
+
   persistence:
     subPath:
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
3. Please do not edit/bump the Chart.yaml "version" field
-->

**What this PR does**:
Adds a `HorizontalPodAutoscaler` for the distributors.

> Distributors are stateless and can be scaled up and down as needed.

... so this adds the option of automating the scaling.

**Checklist**
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`