### PR TITLE
add autoscaler for queriers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## master / unreleased
 
+* [FEATURE] Add autoscaler for queriers #190
 * [FEATURE] Add autoscaler for distributors #189
 * [FEATURE] Add autoscaler for ingesters #182
 * [ENHANCEMENT] Define namespace in templates #184

--- a/README.md
+++ b/README.md
@@ -631,6 +631,12 @@ Kubernetes: `^1.19.0-0`
 | querier.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].podAffinityTerm.topologyKey | string | `"kubernetes.io/hostname"` |  |
 | querier.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].weight | int | `100` |  |
 | querier.annotations | object | `{}` |  |
+| querier.autoscaling.behavior | object | `{}` | Ref: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#support-for-configurable-scaling-behavior |
+| querier.autoscaling.enabled | bool | `false` | Creates a HorizontalPodAutoscaler for the querier pods. |
+| querier.autoscaling.maxReplicas | int | `30` |  |
+| querier.autoscaling.minReplicas | int | `2` |  |
+| querier.autoscaling.targetCPUUtilizationPercentage | int | `80` |  |
+| querier.autoscaling.targetMemoryUtilizationPercentage | int | `0` |  |
 | querier.containerSecurityContext.enabled | bool | `true` |  |
 | querier.containerSecurityContext.readOnlyRootFilesystem | bool | `true` |  |
 | querier.env | list | `[]` |  |

--- a/ci/test-values.yaml
+++ b/ci/test-values.yaml
@@ -67,5 +67,8 @@ distributor:
   autoscaling:
     enabled: true
     minReplicas: 1
+querier:
+  autoscaling:
+    enabled: true
 nginx:
   replicas: 1

--- a/templates/querier/querier-dep.yaml
+++ b/templates/querier/querier-dep.yaml
@@ -8,7 +8,9 @@ metadata:
   annotations:
     {{- toYaml .Values.querier.annotations | nindent 4 }}
 spec:
+  {{- if not .Values.querier.autoscaling.enabled }}
   replicas: {{ .Values.querier.replicas }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "cortex.querierSelectorLabels" . | nindent 6 }}

--- a/templates/querier/querier-hpa.yaml
+++ b/templates/querier/querier-hpa.yaml
@@ -1,0 +1,39 @@
+{{- with .Values.querier.autoscaling -}}
+{{- if .enabled }}
+apiVersion: autoscaling/v2beta2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "cortex.querierFullname" $ }}
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    {{- include "cortex.querierLabels" $ | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "cortex.querierFullname" $ }}
+  minReplicas: {{ .minReplicas }}
+  maxReplicas: {{ .maxReplicas }}
+  metrics:
+  {{- with .targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ . }}
+  {{- end }}
+  {{- with .targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ . }}
+  {{- end }}
+  {{- with .behavior }}
+  behavior:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -819,6 +819,17 @@ querier:
             topologyKey: 'kubernetes.io/hostname'
 
   annotations: {}
+
+  autoscaling:
+    # -- Creates a HorizontalPodAutoscaler for the querier pods.
+    enabled: false
+    minReplicas: 2
+    maxReplicas: 30
+    targetCPUUtilizationPercentage: 80
+    targetMemoryUtilizationPercentage: 0  # 80
+    # -- Ref: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#support-for-configurable-scaling-behavior
+    behavior: {}
+
   persistence:
     subPath:
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
3. Please do not edit/bump the Chart.yaml "version" field
-->

**What this PR does**:
Adds a `HorizontalPodAutoscaler` for the queriers.

https://cortexmetrics.io/docs/architecture/#querier
> Queriers are stateless and can be scaled up and down as needed.



**Checklist**
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`