### PR TITLE
[ENHANCEMENT] Add a nginx config to authenticate requests to query-frontend svc (multi-tenancy)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * [ENHANCEMENT] Define namespace in templates #184
 * [ENHANCEMENT] Use FQDN for memcached addresses #175
 * [ENHANCEMENT] Optionally generate endpoints for `X-Scope-OrgID` injection (multi-tenancy) #180
+* [ENHANCEMENT] Add a nginx config to authenticate requests to query-frontend svc (multi-tenancy) #194
 * [BUGFIX] Correcting nginx config for auth orgs to right proxy_pass #192
 
 ## 0.6.0 / 2021-06-28

--- a/templates/nginx/nginx-config.yaml
+++ b/templates/nginx/nginx-config.yaml
@@ -109,6 +109,11 @@ data:
           proxy_set_header      X-Scope-OrgID {{ $org }};
           proxy_pass      http://{{ template "cortex.fullname" $ }}-distributor.{{ $rootDomain }}/api/v1/push;
         }
+        location ~ ^{{$.Values.config.api.prometheus_http_prefix}}/api/v1/{{ $org }}/(read|metadata|labels|series|query_range|query) {
+          proxy_set_header      X-Scope-OrgID {{ $org }};
+          rewrite ^(/{{$.Values.config.api.prometheus_http_prefix}}/.*)/{{ $org }}/(\w+)\.?.*$ $1/$2 last;
+          proxy_pass      http://{{ template "cortex.fullname" $ }}-query-frontend.{{ $rootDomain }}$request_uri;
+        }
         {{- end }}
         {{- end }}
       }


### PR DESCRIPTION
**What this PR does**: Adds a nginx config to authenticate requests to query-frontend svc when multi-tenancy is enabled. see https://cortexmetrics.io/docs/api/#authentication and https://cortexmetrics.io/docs/api/#querier--query-frontend

**Which issue(s) this PR fixes**: None

**Checklist**
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`