### PR TITLE
graceful shutdown of ingesters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * [FEATURE] Add autoscaler for queriers #190
 * [FEATURE] Add autoscaler for distributors #189
 * [FEATURE] Add autoscaler for ingesters #182
+* [ENHANCEMENT] Graceful shutdown of ingesters #195
 * [ENHANCEMENT] Define namespace in templates #184
 * [ENHANCEMENT] Use FQDN for memcached addresses #175
 * [ENHANCEMENT] Optionally generate endpoints for `X-Scope-OrgID` injection (multi-tenancy) #180

--- a/README.md
+++ b/README.md
@@ -482,6 +482,7 @@ Kubernetes: `^1.19.0-0`
 | ingester.extraVolumeMounts | list | `[]` |  |
 | ingester.extraVolumes | list | `[]` |  |
 | ingester.initContainers | list | `[]` |  |
+| ingester.lifecycle.preStop | object | `{"httpGet":{"path":"/ingester/shutdown","port":"http-metrics"}}` | The /shutdown preStop hook is recommended as part of the ingester scaledown process, but can be removed to optimize rolling restarts in instances that will never be scaled down or when using chunks storage with WAL disabled. https://cortexmetrics.io/docs/guides/ingesters-scaling-up-and-down/#scaling-down |
 | ingester.livenessProbe.httpGet.path | string | `"/ready"` |  |
 | ingester.livenessProbe.httpGet.port | string | `"http-metrics"` |  |
 | ingester.livenessProbe.httpGet.scheme | string | `"HTTP"` |  |

--- a/README.md
+++ b/README.md
@@ -466,7 +466,8 @@ Kubernetes: `^1.19.0-0`
 | ingester.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].podAffinityTerm.topologyKey | string | `"kubernetes.io/hostname"` |  |
 | ingester.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].weight | int | `100` |  |
 | ingester.annotations | object | `{}` |  |
-| ingester.autoscaling.behavior.scaleDown.selectPolicy | string | `"Disabled"` | Scaledown procedure varies, so automatic scaledown is disabled Ref: https://cortexmetrics.io/docs/guides/ingesters-scaling-up-and-down/#scaling-down |
+| ingester.autoscaling.behavior.scaleDown.policies | list | `[{"periodSeconds":1800,"type":"Pods","value":1}]` | see https://cortexmetrics.io/docs/guides/ingesters-scaling-up-and-down/#scaling-down for scaledown details |
+| ingester.autoscaling.behavior.scaleDown.stabilizationWindowSeconds | int | `3600` | uses metrics from the past 1h to make scaleDown decisions |
 | ingester.autoscaling.behavior.scaleUp.policies | list | `[{"periodSeconds":1800,"type":"Pods","value":1}]` | This default scaleup policy allows adding 1 pod every 30 minutes. Ref: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#support-for-configurable-scaling-behavior |
 | ingester.autoscaling.enabled | bool | `false` |  |
 | ingester.autoscaling.maxReplicas | int | `30` |  |

--- a/templates/ingester/ingester-dep.yaml
+++ b/templates/ingester/ingester-dep.yaml
@@ -103,11 +103,10 @@ spec:
             {{- if .Values.ingester.env }}
             {{ toYaml .Values.ingester.env | nindent 12 }}
             {{- end }}
+          {{- with .Values.ingester.lifecycle }}
           lifecycle:
-            preStop:
-              httpGet:
-                path: "/ingester/shutdown"
-                port: {{ .Values.config.server.http_listen_port }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
         {{- with .Values.ingester.extraContainers }}
         {{ toYaml . | nindent 8 }}
         {{- end }}

--- a/templates/ingester/ingester-dep.yaml
+++ b/templates/ingester/ingester-dep.yaml
@@ -103,6 +103,11 @@ spec:
             {{- if .Values.ingester.env }}
             {{ toYaml .Values.ingester.env | nindent 12 }}
             {{- end }}
+          lifecycle:
+            preStop:
+              httpGet:
+                path: "/ingester/shutdown"
+                port: {{ .Values.config.server.http_listen_port }}
         {{- with .Values.ingester.extraContainers }}
         {{ toYaml . | nindent 8 }}
         {{- end }}

--- a/templates/ingester/ingester-statefulset.yaml
+++ b/templates/ingester/ingester-statefulset.yaml
@@ -151,4 +151,9 @@ spec:
             {{- if .Values.ingester.env }}
               {{- toYaml .Values.ingester.env | nindent 12 }}
             {{- end }}
+          lifecycle:
+            preStop:
+              httpGet:
+                path: "/ingester/shutdown"
+                port: {{ .Values.config.server.http_listen_port }}
 {{- end -}}

--- a/templates/ingester/ingester-statefulset.yaml
+++ b/templates/ingester/ingester-statefulset.yaml
@@ -151,9 +151,8 @@ spec:
             {{- if .Values.ingester.env }}
               {{- toYaml .Values.ingester.env | nindent 12 }}
             {{- end }}
+          {{- with .Values.ingester.lifecycle }}
           lifecycle:
-            preStop:
-              httpGet:
-                path: "/ingester/shutdown"
-                port: {{ .Values.config.server.http_listen_port }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
 {{- end -}}

--- a/values.yaml
+++ b/values.yaml
@@ -537,9 +537,14 @@ ingester:
     targetMemoryUtilizationPercentage: 80
     behavior:
       scaleDown:
-        # -- Scaledown procedure varies, so automatic scaledown is disabled
-        # Ref: https://cortexmetrics.io/docs/guides/ingesters-scaling-up-and-down/#scaling-down
-        selectPolicy: Disabled
+        # -- see https://cortexmetrics.io/docs/guides/ingesters-scaling-up-and-down/#scaling-down for scaledown details
+        policies:
+          - type: Pods
+            value: 1
+            # set to no less than 2x the maximum between -blocks-storage.bucket-store.sync-interval and -compactor.cleanup-interval
+            periodSeconds: 1800
+        # -- uses metrics from the past 1h to make scaleDown decisions
+        stabilizationWindowSeconds: 3600
       scaleUp:
         # -- This default scaleup policy allows adding 1 pod every 30 minutes.
         # Ref: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#support-for-configurable-scaling-behavior

--- a/values.yaml
+++ b/values.yaml
@@ -553,6 +553,17 @@ ingester:
             value: 1
             periodSeconds: 1800
 
+  lifecycle:
+    # -- The /shutdown preStop hook is recommended as part of the ingester
+    # scaledown process, but can be removed to optimize rolling restarts in
+    # instances that will never be scaled down or when using chunks storage
+    # with WAL disabled.
+    # https://cortexmetrics.io/docs/guides/ingesters-scaling-up-and-down/#scaling-down
+    preStop:
+      httpGet:
+        path: "/ingester/shutdown"
+        port: http-metrics
+
   ## DEPRECATED: use persistentVolume.subPath instead
   persistence:
     subPath:


### PR DESCRIPTION
**What this PR does**:
https://cortexmetrics.io/docs/api/#shutdown says that `/ingester/shutdown` should be called before sending SIGTERM to an ingester. This PR adds a preStop hook to do that. This gives the ingester an opportunity to safely flush blocks from memory before being terminated.

#### Reference:
* https://cortexmetrics.io/docs/api/#shutdown
* https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
* https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#lifecycle-v1-core

**Checklist**
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`