### PR TITLE
Populate config.querier.store_gateway_addresses automatically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * [FEATURE] Add autoscaler for queriers #190
 * [FEATURE] Add autoscaler for distributors #189
 * [FEATURE] Add autoscaler for ingesters #182
+* [ENHANCEMENT] Populate config.querier.store_gateway_addresses automatically based on other config #201
 * [ENHANCEMENT] Graceful shutdown of ingesters #195
 * [ENHANCEMENT] Define namespace in templates #184
 * [ENHANCEMENT] Use FQDN for memcached addresses #175

--- a/README.md
+++ b/README.md
@@ -329,6 +329,7 @@ Kubernetes: `^1.19.0-0`
 | config.&ZeroWidthSpace;memberlist.&ZeroWidthSpace;join_members | list | `[]` | the service name of the memberlist if using memberlist discovery |
 | config.&ZeroWidthSpace;querier.&ZeroWidthSpace;active_query_tracker_dir | string | `"/data/cortex/querier"` |  |
 | config.&ZeroWidthSpace;querier.&ZeroWidthSpace;query_ingesters_within | string | `"12h"` |  |
+| config.&ZeroWidthSpace;querier.&ZeroWidthSpace;store_gateway_addresses | string | automatic | Comma separated list of store-gateway addresses in DNS Service Discovery format. This option should is set automatically when using the blocks storage and the store-gateway sharding is disabled (when enabled, the store-gateway instances form a ring and addresses are picked from the ring). |
 | config.&ZeroWidthSpace;query_range.&ZeroWidthSpace;align_queries_with_step | bool | `true` |  |
 | config.&ZeroWidthSpace;query_range.&ZeroWidthSpace;cache_results | bool | `true` |  |
 | config.&ZeroWidthSpace;query_range.&ZeroWidthSpace;results_cache.&ZeroWidthSpace;cache.&ZeroWidthSpace;memcached.&ZeroWidthSpace;expiration | string | `"1h"` |  |
@@ -361,6 +362,7 @@ Kubernetes: `^1.19.0-0`
 | config.&ZeroWidthSpace;storage.&ZeroWidthSpace;engine | string | `"chunks"` |  |
 | config.&ZeroWidthSpace;storage.&ZeroWidthSpace;index_queries_cache_config.&ZeroWidthSpace;memcached.&ZeroWidthSpace;expiration | string | `"1h"` |  |
 | config.&ZeroWidthSpace;storage.&ZeroWidthSpace;index_queries_cache_config.&ZeroWidthSpace;memcached_client.&ZeroWidthSpace;timeout | string | `"1s"` |  |
+| config.&ZeroWidthSpace;store_gateway | object | `{}` | https://cortexmetrics.io/docs/configuration/configuration-file/#store_gateway_config |
 | config.&ZeroWidthSpace;table_manager.&ZeroWidthSpace;retention_deletes_enabled | bool | `false` |  |
 | config.&ZeroWidthSpace;table_manager.&ZeroWidthSpace;retention_period | string | `"0s"` |  |
 | configs.&ZeroWidthSpace;affinity | object | `{}` |  |

--- a/ci/test-values.yaml
+++ b/ci/test-values.yaml
@@ -48,9 +48,6 @@ config:
     filesystem:
       dir: "/data/store"
 
-  querier:
-    store_gateway_addresses: 'dns+{{ include "cortex.storeGatewayFullname" $ }}-headless:9095'
-
   memberlist:
     join_members:
       - '{{ include "cortex.fullname" $ }}-memberlist'

--- a/values.yaml
+++ b/values.yaml
@@ -134,6 +134,8 @@ config:
         expiration: 1h
       memcached_client:
         timeout: 1s
+  # -- https://cortexmetrics.io/docs/configuration/configuration-file/#store_gateway_config
+  store_gateway: {}
   table_manager:
     retention_deletes_enabled: false
     retention_period: 0s
@@ -150,11 +152,15 @@ config:
   querier:
     active_query_tracker_dir: /data/cortex/querier
     query_ingesters_within: 12h
-    # Comma separated list of store-gateway addresses in DNS Service Discovery
-    # format. This option should be set when using the blocks storage and the
+    # -- Comma separated list of store-gateway addresses in DNS Service Discovery
+    # format. This option should is set automatically when using the blocks storage and the
     # store-gateway sharding is disabled (when enabled, the store-gateway instances
     # form a ring and addresses are picked from the ring).
-    # store_gateway_addresses: 'dns+{{ include "cortex.storeGatewayFullname" $ }}-headless:9095'
+    # @default -- automatic
+    store_gateway_addresses: |-
+      {{ if and (eq .Values.config.storage.engine "blocks") (not .Values.config.store_gateway.sharding_enabled) -}}
+      dns+{{ include "cortex.storeGatewayFullname" $ }}-headless:9095
+      {{- end }}
   query_range:
     split_queries_by_interval: 24h
     align_queries_with_step: true


### PR DESCRIPTION
**What this PR does**:
Populate `config.querier.store_gateway_addresses` automatically based on other config

**Checklist**
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`