### PR TITLE
Add basic auth configuration options to Nginx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * [ENHANCEMENT] Define namespace in templates #184
 * [ENHANCEMENT] Use FQDN for memcached addresses #175
 * [ENHANCEMENT] Optionally generate endpoints for `X-Scope-OrgID` injection (multi-tenancy) #180
+* [ENHANCEMENT] Optionally configure Basic Auth within Nginx #205
 * [BUGFIX] Fix whitespace in runtime-config annotations, introduced in #209, fixed in #212
 * [BUGFIX] Correcting nginx config for auth orgs to right proxy_pass #192
 

--- a/README.md
+++ b/README.md
@@ -588,6 +588,7 @@ Kubernetes: `^1.19.0-0`
 | nginx.&ZeroWidthSpace;affinity | object | `{}` |  |
 | nginx.&ZeroWidthSpace;annotations | object | `{}` |  |
 | nginx.&ZeroWidthSpace;config.&ZeroWidthSpace;auth_orgs | list | `[]` | (optional) List of [auth tenants](https://cortexmetrics.io/docs/guides/auth/) to set in the nginx config |
+| nginx.&ZeroWidthSpace;config.&ZeroWidthSpace;basicAuthSecretName | string | `""` | (optional) Name of basic auth secret. In order to use this option, a secret with htpasswd formatted contents at the key ".htpasswd" must exist. For example:   apiVersion: v1   kind: Secret   metadata:     name: my-secret     namespace: <same as cortex installation>   stringData:     .htpasswd: |       user1:$apr1$/woC1jnP$KAh0SsVn5qeSMjTtn0E9Q0       user2:$apr1$QdR8fNLT$vbCEEzDj7LyqCMyNpSoBh/ Please note that the use of basic auth will not identify organizations the way X-Scope-OrgID does. Thus, the use of basic auth alone will not prevent one tenant from viewing the metrics of another. To ensure tenants are scoped appropriately, explicitly set the `X-Scope-OrgID` header in the nginx config. Example   setHeaders:     X-Scope-Org-Id: $remote_user |
 | nginx.&ZeroWidthSpace;config.&ZeroWidthSpace;client_max_body_size | string | `"1M"` |  |
 | nginx.&ZeroWidthSpace;config.&ZeroWidthSpace;dnsResolver | string | `"kube-dns.kube-system.svc.cluster.local"` |  |
 | nginx.&ZeroWidthSpace;config.&ZeroWidthSpace;setHeaders | object | `{}` |  |

--- a/templates/nginx/nginx-config.yaml
+++ b/templates/nginx/nginx-config.yaml
@@ -40,7 +40,18 @@ data:
         proxy_set_header {{ $key }} {{ $value }};
         {{- end }}
 
+        {{ if .Values.nginx.config.basicAuthSecretName -}}
+        auth_basic "Restricted Content";
+        auth_basic_user_file /etc/apache2/.htpasswd;
+        {{- end }}
+
         location = /healthz {
+          # auth_basic off is not set here, even when a basic auth directive is
+          # included in the server block, as Nginx's NGX_HTTP_REWRITE_PHASE
+          # (point when this return statement is evaluated) comes before the
+          # NGX_HTTP_ACCESS_PHASE (point when basic auth is evaluated). Thus,
+          # this return statement returns a response before basic auth is
+          # evaluated.
           return 200 'alive';
         }
 

--- a/templates/nginx/nginx-dep.yaml
+++ b/templates/nginx/nginx-dep.yaml
@@ -59,6 +59,11 @@ spec:
             {{- end }}
             - name: config
               mountPath: /etc/nginx
+            {{- if .Values.nginx.config.basicAuthSecretName }}
+            - name: htpasswd
+              mountPath: /etc/apache2
+              readOnly: true
+            {{- end }}
           ports:
             - name: http-metrics
               containerPort: {{ .Values.nginx.http_listen_port }}
@@ -92,6 +97,12 @@ spec:
         - name: config
           configMap:
             name: {{ template "cortex.fullname" . }}-nginx
+        {{- if .Values.nginx.config.basicAuthSecretName }}
+        - name: htpasswd
+          secret:
+            defaultMode: 420
+            secretName: {{ .Values.nginx.config.basicAuthSecretName }}
+        {{- end }}
 {{- if .Values.nginx.extraVolumes }}
 {{ toYaml .Values.nginx.extraVolumes | indent 8}}
 {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -1165,6 +1165,29 @@ nginx:
     setHeaders: {}
     # -- (optional) List of [auth tenants](https://cortexmetrics.io/docs/guides/auth/) to set in the nginx config
     auth_orgs: []
+    # -- (optional) Name of basic auth secret.
+    # In order to use this option, a secret with htpasswd formatted contents at
+    # the key ".htpasswd" must exist. For example:
+    #
+    #   apiVersion: v1
+    #   kind: Secret
+    #   metadata:
+    #     name: my-secret
+    #     namespace: <same as cortex installation>
+    #   stringData:
+    #     .htpasswd: |
+    #       user1:$apr1$/woC1jnP$KAh0SsVn5qeSMjTtn0E9Q0
+    #       user2:$apr1$QdR8fNLT$vbCEEzDj7LyqCMyNpSoBh/
+    #
+    # Please note that the use of basic auth will not identify organizations
+    # the way X-Scope-OrgID does. Thus, the use of basic auth alone will not
+    # prevent one tenant from viewing the metrics of another. To ensure tenants
+    # are scoped appropriately, explicitly set the `X-Scope-OrgID` header
+    # in the nginx config. Example
+    #   setHeaders:
+    #     X-Scope-Org-Id: $remote_user
+    basicAuthSecretName: ""
+
   image:
     repository: nginx
     tag: 1.21


### PR DESCRIPTION


**What this PR does**:
  This commit adds the ability to include an `auth_basic` and
  `auth_basic_user_file` directive in the Nginx configuration file.

**Which issue(s) this PR fixes**:
Fixes #205 

**Checklist**
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`