### PR TITLE
fix runtimeconfigmap annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * [ENHANCEMENT] Define namespace in templates #184
 * [ENHANCEMENT] Use FQDN for memcached addresses #175
 * [ENHANCEMENT] Optionally generate endpoints for `X-Scope-OrgID` injection (multi-tenancy) #180
+* [BUGFIX] Fix whitespace in runtime-config annotations, introduced in #209, fixed in #212
 * [BUGFIX] Correcting nginx config for auth orgs to right proxy_pass #192
 
 ## 0.6.0 / 2021-06-28

--- a/ci/test-values.yaml
+++ b/ci/test-values.yaml
@@ -69,6 +69,9 @@ querier:
     enabled: true
 nginx:
   replicas: 1
+runtimeconfigmap:
+  annotations:
+    foo: bar
 
 tags:
   blocks-storage-memcached: true

--- a/templates/runtime-configmap.yaml
+++ b/templates/runtime-configmap.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: {{ $.Release.Namespace }}
   labels:
     {{- include "cortex.labels" $ | nindent 4 }}
-  {{- with .annotations -}}
+  {{- with .annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}


### PR DESCRIPTION
**What this PR does**:
#209 had a whitespace bug in the annotations section. It would eat the whitespace between the `labels:` and `annotations:`. Here's an example of the problem:
```yaml
% helm template . -f ci/test-values.yaml -s templates/runtime-configmap.yaml --debug
install.go:173: [debug] Original chart version: ""
install.go:190: [debug] CHART PATH: /Users/thayward/go/src/github.com/cortexproject/cortex-helm-chart

---
# Source: cortex/templates/runtime-configmap.yaml

apiVersion: v1
kind: ConfigMap
metadata:
  name: RELEASE-NAME-cortex-runtime-config
  namespace: default
  labels:
    helm.sh/chart: cortex-0.6.0
    app.kubernetes.io/name: cortex
    app.kubernetes.io/instance: RELEASE-NAME
    app.kubernetes.io/version: "v1.9.0"
    app.kubernetes.io/managed-by: Helmannotations:
    foo: bar
data:
  runtime_config.yaml: |
    {}
Error: YAML parse error on cortex/templates/runtime-configmap.yaml: error converting YAML to JSON: yaml: line 11: mapping values are not allowed in this context
helm.go:81: [debug] error converting YAML to JSON: yaml: line 11: mapping values are not allowed in this context
YAML parse error on cortex/templates/runtime-configmap.yaml
helm.sh/helm/v3/pkg/releaseutil.(*manifestFile).sort
        helm.sh/helm/v3/pkg/releaseutil/manifest_sorter.go:146
helm.sh/helm/v3/pkg/releaseutil.SortManifests
        helm.sh/helm/v3/pkg/releaseutil/manifest_sorter.go:106
helm.sh/helm/v3/pkg/action.(*Configuration).renderResources
        helm.sh/helm/v3/pkg/action/action.go:165
helm.sh/helm/v3/pkg/action.(*Install).Run
        helm.sh/helm/v3/pkg/action/install.go:247
main.runInstall
        helm.sh/helm/v3/cmd/helm/install.go:242
main.newTemplateCmd.func2
        helm.sh/helm/v3/cmd/helm/template.go:82
github.com/spf13/cobra.(*Command).execute
        github.com/spf13/cobra@v1.1.3/command.go:852
github.com/spf13/cobra.(*Command).ExecuteC
        github.com/spf13/cobra@v1.1.3/command.go:960
github.com/spf13/cobra.(*Command).Execute
        github.com/spf13/cobra@v1.1.3/command.go:897
main.main
        helm.sh/helm/v3/cmd/helm/helm.go:80
runtime.main
        runtime/proc.go:225
runtime.goexit
        runtime/asm_amd64.s:1371
```

**Checklist**
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`