### PR TITLE
Support customizing the nginx config with values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * [FEATURE] Add autoscaler for queriers #190
 * [FEATURE] Add autoscaler for distributors #189
 * [FEATURE] Add autoscaler for ingesters #182
+* [ENHANCEMENT] Support customizing the nginx config with values #213
 * [ENHANCEMENT] Upgrade to Cortex v1.10.0 #204
 * [ENHANCEMENT] Populate config.querier.store_gateway_addresses automatically based on other config #201
 * [ENHANCEMENT] Graceful shutdown of ingesters #195

--- a/README.md
+++ b/README.md
@@ -591,6 +591,9 @@ Kubernetes: `^1.19.0-0`
 | nginx.&ZeroWidthSpace;config.&ZeroWidthSpace;basicAuthSecretName | string | `""` | (optional) Name of basic auth secret. In order to use this option, a secret with htpasswd formatted contents at the key ".htpasswd" must exist. For example:   apiVersion: v1   kind: Secret   metadata:     name: my-secret     namespace: <same as cortex installation>   stringData:     .htpasswd: |       user1:$apr1$/woC1jnP$KAh0SsVn5qeSMjTtn0E9Q0       user2:$apr1$QdR8fNLT$vbCEEzDj7LyqCMyNpSoBh/ Please note that the use of basic auth will not identify organizations the way X-Scope-OrgID does. Thus, the use of basic auth alone will not prevent one tenant from viewing the metrics of another. To ensure tenants are scoped appropriately, explicitly set the `X-Scope-OrgID` header in the nginx config. Example   setHeaders:     X-Scope-Org-Id: $remote_user |
 | nginx.&ZeroWidthSpace;config.&ZeroWidthSpace;client_max_body_size | string | `"1M"` |  |
 | nginx.&ZeroWidthSpace;config.&ZeroWidthSpace;dnsResolver | string | `"kube-dns.kube-system.svc.cluster.local"` |  |
+| nginx.&ZeroWidthSpace;config.&ZeroWidthSpace;httpSnippet | string | `""` | arbitrary snippet to inject in the http { } section of the nginx config |
+| nginx.&ZeroWidthSpace;config.&ZeroWidthSpace;mainSnippet | string | `""` | arbitrary snippet to inject in the top section of the nginx config |
+| nginx.&ZeroWidthSpace;config.&ZeroWidthSpace;serverSnippet | string | `""` | arbitrary snippet to inject in the server { } section of the nginx config |
 | nginx.&ZeroWidthSpace;config.&ZeroWidthSpace;setHeaders | object | `{}` |  |
 | nginx.&ZeroWidthSpace;containerSecurityContext.&ZeroWidthSpace;enabled | bool | `true` |  |
 | nginx.&ZeroWidthSpace;containerSecurityContext.&ZeroWidthSpace;readOnlyRootFilesystem | bool | `false` |  |

--- a/ci/test-values.yaml
+++ b/ci/test-values.yaml
@@ -69,6 +69,13 @@ querier:
     enabled: true
 nginx:
   replicas: 1
+  config:
+    httpSnippet: |-
+      # http snippet
+    mainSnippet: |-
+      # main snippet
+    serverSnippet: |-
+      # server snippet
 runtimeconfigmap:
   annotations:
     foo: bar

--- a/templates/nginx/nginx-config.yaml
+++ b/templates/nginx/nginx-config.yaml
@@ -18,6 +18,10 @@ data:
       worker_connections  4096;  ## Default: 1024
     }
 
+    {{- with .Values.nginx.config.mainSnippet }}
+    {{ tpl . $ | nindent 4 }}
+    {{- end }}
+
     http {
       default_type application/octet-stream;
       client_max_body_size {{.Values.nginx.config.client_max_body_size}};
@@ -28,6 +32,10 @@ data:
       sendfile     on;
       tcp_nopush   on;
       resolver {{ default (printf "kube-dns.kube-system.svc.%s" .Values.clusterDomain ) .Values.nginx.config.dnsResolver }};
+
+      {{- with .Values.nginx.config.httpSnippet }}
+      {{ tpl . $ | nindent 6 }}
+      {{- end }}
 
       server { # simple reverse-proxy
         listen {{ .Values.nginx.http_listen_port }};
@@ -43,6 +51,10 @@ data:
         {{ if .Values.nginx.config.basicAuthSecretName -}}
         auth_basic "Restricted Content";
         auth_basic_user_file /etc/apache2/.htpasswd;
+        {{- end }}
+
+        {{- with .Values.nginx.config.serverSnippet }}
+        {{ tpl . $ | nindent 8 }}
         {{- end }}
 
         location = /healthz {

--- a/values.yaml
+++ b/values.yaml
@@ -1162,6 +1162,12 @@ nginx:
     dnsResolver: kube-dns.kube-system.svc.cluster.local
     ## ref: http://nginx.org/en/docs/http/ngx_http_core_module.html#client_max_body_size
     client_max_body_size: 1M
+    # -- arbitrary snippet to inject in the http { } section of the nginx config
+    httpSnippet: ""
+    # -- arbitrary snippet to inject in the top section of the nginx config
+    mainSnippet: ""
+    # -- arbitrary snippet to inject in the server { } section of the nginx config
+    serverSnippet: ""
     setHeaders: {}
     # -- (optional) List of [auth tenants](https://cortexmetrics.io/docs/guides/auth/) to set in the nginx config
     auth_orgs: []


### PR DESCRIPTION
**What this PR does**:
There are a lot of use cases for nginx and not all of them are supported by the chart. This change allows adding custom configuration to nginx, so that users can implement what they need with nginx without a change to the chart.

**Checklist**
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`