### PR TITLE
Fix nil pointer evalutation in ruler configmap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master / unreleased
 
+* [BUGFIX] Fix nil pointer evaluation when using `ruler.dictonaries` option #242
+
 ## 0.7.0 / 2021-10-05
 
 * [FEATURE] Support runtime configuration #209

--- a/templates/ruler/ruler-configmap.yaml
+++ b/templates/ruler/ruler-configmap.yaml
@@ -5,7 +5,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "cortex.rulerFullname" $ }}-{{ include "cortex.rulerRulesDirName" $dir }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ $.Release.Namespace }}
   labels:
     {{- include "cortex.rulerLabels" $ | nindent 4 }}
 data:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
3. Please do not edit/bump the Chart.yaml "version" field
-->

**What this PR does**: This fixes the nil pointer evaluation when using the directories option.

>template: cortex/templates/ruler/ruler-configmap.yaml:8:24: executing "cortex/templates/ruler/ruler-configmap.yaml" at <.Release.Namespace>: nil pointer evaluating interface {}.Namespace

This change is required since we change the `.` scope with the `range` loop in line 2 of that file which means what `.` does no longer contain `Releases` and `Namespace`.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`