### PR TITLE
update default values.yaml

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -17,7 +17,7 @@ image:
 clusterDomain: cluster.local
 
 tags:
-  blocks-storage-memcached: false
+  blocks-storage-memcached: true
 
 ingress:
   enabled: false
@@ -44,6 +44,8 @@ externalConfigSecretName: 'secret-with-config.yaml'
 externalConfigVersion: '0'
 
 config:
+  # Disable the requirement that every request to Cortex has a
+  # X-Scope-OrgID header. `fake` will be substituted instead.
   auth_enabled: false
   api:
     prometheus_http_prefix: '/prometheus'
@@ -55,31 +57,18 @@ config:
       final_sleep: 0s
       num_tokens: 512
       ring:
-        replication_factor: 3
+        replication_factor: 1
         kvstore:
-          store: consul
-          prefix: 'collectors/'
-          consul:
-            host: 'consul:8500'
-            http_client_timeout: '20s'
-            consistent_reads: true
+            store: "memberlist"
+    walconfig:
+      wal_enabled: true
+      recover_from_wal: true
+      wal_dir: "/data/wal"
   limits:
     enforce_metric_name: false
     reject_old_samples: true
     reject_old_samples_max_age: 168h
     max_query_lookback: 0s
-  schema:
-    configs:
-      - from: 2020-11-01
-        store: cassandra
-        object_store: cassandra
-        schema: v10
-        index:
-          prefix: index_
-          period: 168h
-        chunks:
-          prefix: chunks_
-          period: 168h
   server:
     http_listen_port: 8080
     grpc_listen_port: 9095
@@ -92,48 +81,57 @@ config:
       max_send_msg_size: 104857600
   # See https://github.com/cortexproject/cortex/blob/master/docs/configuration/config-file-reference.md#storage_config
   storage:
-    engine: chunks
-    cassandra:
-      addresses:                  # configure cassandra addresses here.
-      keyspace: cortex            # configure desired keyspace here.
-      auth: true
-      username:                   # configure cassandra user here.
-      password:                   # configure cassandra password here.
-    azure:
-      container_name:             # configure azure blob container name here.
-      account_name:               # configure azure storage account name here.
-      account_key:                # configure azure storage account key here.
-    # aws:
-    #   dynamodb:
-    #     dynamodb_url:
-    #     api_limit:
-    #     throttle_limit:
-    #     metrics:
-    #       url:
-    #       target_queue_length:
-    #       scale_up_factor:
-    #       ignore_throttle_below:
-    #       queue_length_query:
-    #       write_throttle_query:
-    #       write_usage_query:
-    #       read_usage_query:
-    #       read_error_query:
-    #     chunk_gang_size:
-    #     chunk_get_max_parallelism:
-    #   s3:
-    #   bucketnames:
-    #   s3forcepathstyle:
-    index_queries_cache_config:
-      memcached:
-        expiration: 1h
-      memcached_client:
-        timeout: 1s
-  chunk_store:
-    chunk_cache_config:
-      memcached:
-        expiration: 1h
-      memcached_client:
-        timeout: 1s
+    engine: blocks
+  blocks_storage:
+    backend: "filesystem"
+    filesystem:
+      dir: "/data/blocks-storage"
+    # backend: "gcs"
+    # gcs:
+    #   bucket_name: ""
+    #   service_account: "" # json credentials
+    bucket_store:
+      sync_dir: "data"
+      index_cache:
+        backend: memcached
+        memcached:
+          addresses: 'dns+{{ include "cortex.fullname" $ }}-memcached-blocks-index:11211'
+          timeout: 300ms
+          max_idle_connections: 750
+          max_async_concurrency: 100
+          max_async_buffer_size: 10000000
+          max_get_multi_concurrency: 750
+          max_get_multi_batch_size: 1000
+          max_item_size: 16777216
+      chunks_cache:
+        backend: memcached
+        memcached:
+          addresses: 'dns+{{ include "cortex.fullname" $ }}-memcached-blocks:11211'
+          timeout: 300ms
+          max_idle_connections: 750
+          max_async_concurrency: 100
+          max_async_buffer_size: 10000000
+          max_get_multi_concurrency: 750
+          max_get_multi_batch_size: 1000
+          max_item_size: 33554432
+      metadata_cache:
+        backend: memcached          
+        memcached:
+          addresses: 'dns+{{ include "cortex.fullname" $ }}-blocks-metadata:11211'
+          timeout: 300ms
+          max_idle_connections: 750
+          max_async_concurrency: 100
+          max_async_buffer_size: 10000000
+          max_get_multi_concurrency: 750
+          max_get_multi_batch_size: 1000
+          max_item_size: 16777216
+    # index_queries_cache_config:
+    #   memcached:
+    #     expiration: 1h
+    #   memcached_client:
+    #     timeout: 1s
+    tsdb:
+      dir: "/data"
   # -- https://cortexmetrics.io/docs/configuration/configuration-file/#store_gateway_config
   store_gateway: {}
   table_manager:
@@ -143,12 +141,15 @@ config:
     shard_by_all_labels: true
     pool:
       health_check_ingesters: true
+    ring:
+      kvstore:
+        store: memberlist
   memberlist:
     bind_port: 7946
     # -- the service name of the memberlist
     # if using memberlist discovery
-    join_members: []
-    #  - '{{ include "cortex.fullname" $ }}-memberlist'
+    join_members:
+     - '{{ include "cortex.fullname" $ }}-memberlist'
   querier:
     active_query_tracker_dir: /data/cortex/querier
     query_ingesters_within: 12h
@@ -177,6 +178,13 @@ config:
     enable_api: false
     # -- Method to use for backend rule storage (configdb, azure, gcs, s3, swift, local) refer to https://cortexmetrics.io/docs/configuration/configuration-file/#ruler_config
     storage: {}
+    ring:
+      kvstore:
+        store: memberlist
+  ruler_storage:
+    backend: "filesystem"
+    filesystem:
+      dir: "/data/store"
   runtime_config:
     file: /etc/cortex-runtime-config/runtime_config.yaml
   alertmanager:
@@ -185,6 +193,10 @@ config:
     external_url: '/api/prom/alertmanager'
     # -- Type of backend to use to store alertmanager configs. Supported values are: "configdb", "gcs", "s3", "local". refer to: https://cortexmetrics.io/docs/configuration/configuration-file/#alertmanager_config
     storage: {}
+  alertmanager_storage:
+    backend: "filesystem"
+    filesystem:
+      dir: "/data/store"
   frontend:
     #  max_outstanding_per_tenant: 1000
     log_queries_longer_than: 10s
@@ -397,7 +409,7 @@ alertmanager:
       runAsUser: 0
 
 distributor:
-  replicas: 2
+  replicas: 1
 
   service:
     annotations: {}
@@ -500,15 +512,18 @@ distributor:
   env: []
 
 ingester:
-  replicas: 3
+  replicas: 1
 
   statefulSet:
     ## If true, use a statefulset instead of a deployment for pod management.
     ## This is useful when using WAL
     ##
-    enabled: false
+    enabled: true
     # -- see https://cortexmetrics.io/docs/guides/ingesters-scaling-up-and-down/#scaling-down and https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#pod-management-policies for scaledown details
     podManagementPolicy: OrderedReady
+  persistentVolume:
+    size: "1Gi"
+    enabled: true
 
   service:
     annotations: {}
@@ -818,7 +833,7 @@ ruler:
 
 
 querier:
-  replicas: 2
+  replicas: 1
 
   service:
     annotations: {}
@@ -921,7 +936,7 @@ querier:
   env: []
 
 query_frontend:
-  replicas: 2
+  replicas: 1
 
   service:
     annotations: {}
@@ -1174,7 +1189,7 @@ configs:
 
 nginx:
   enabled: true
-  replicas: 2
+  replicas: 1
   http_listen_port: 80
   config:
     dnsResolver: kube-dns.kube-system.svc.cluster.local
@@ -1585,6 +1600,7 @@ memcached:
   #             - cortex-memcached
 
 # index read caching
+# DEPRECATED - Chunck storage
 memcached-index-read:
   enabled: false
   architecture: "high-availability"
@@ -1621,6 +1637,7 @@ memcached-index-read:
   #             - cortex-memcached
 
 # index write caching
+# DEPRECATED - Chunck storage
 memcached-index-write:
   enabled: false
   architecture: "high-availability"
@@ -1657,88 +1674,100 @@ memcached-index-write:
   #             - cortex-memcached
 
 memcached-frontend:
-  enabled: false
+  enabled: true
   architecture: "high-availability"
-  replicaCount: 2
+  replicaCount: 1
   # dpdbMinAvailable: 1
   # image: memcached:1.5.7-alpine
-  memcached:
-    maxItemMemory: 3840
-    extraArgs:
-      - -I 32m
-    threads: 32
+  command:
+    - /run.sh
+    - -m 256
+    - -I 32m
+    - -t 4
+  arguments: []
   resources: {}
   #  requests:
-  #    memory: 1Gi
-  #    cpu: 10m
+  #    memory: 256Mi
+  #    cpu: 250m
   #  limits:
-  #    memory: 4Gi
-  #    cpu: 1
+  #    memory: 256Mi
+  #    cpu: 250m
   metrics:
-    enabled: true
+    enabled: false
+    serviceMonitor:
+      enabled: false
 
 memcached-blocks-index:
   # enabled/disabled via the tags.blocks-storage-memcached boolean
   architecture: "high-availability"
-  replicaCount: 2
+  replicaCount: 1
   # dpdbMinAvailable: 1
   # image: memcached:1.5.7-alpine
-  memcached:
-    maxItemMemory: 3840
-    extraArgs:
-      - -I 32m
-    threads: 32
+  command:
+    - /run.sh
+    - -m 256
+    - -I 32m
+    - -t 4
+  arguments: []
   resources: {}
   #  requests:
-  #    memory: 1Gi
-  #    cpu: 10m
+  #    memory: 256Mi
+  #    cpu: 250m
   #  limits:
-  #    memory: 4Gi
-  #    cpu: 1
+  #    memory: 256Mi
+  #    cpu: 250m
   metrics:
-    enabled: true
+    enabled: false
+    serviceMonitor:
+      enabled: false
 
 memcached-blocks:
   # enabled/disabled via the tags.blocks-storage-memcached boolean
   architecture: "high-availability"
-  replicaCount: 2
+  replicaCount: 1
   # dpdbMinAvailable: 1
   # image: memcached:1.5.7-alpine
-  memcached:
-    maxItemMemory: 3840
-    extraArgs:
-      - -I 32m
-    threads: 32
+  command:
+    - /run.sh
+    - -m 256
+    - -I 32m
+    - -t 4
+  arguments: []
   resources: {}
   #  requests:
-  #    memory: 1Gi
-  #    cpu: 10m
+  #    memory: 256Mi
+  #    cpu: 250m
   #  limits:
-  #    memory: 4Gi
-  #    cpu: 1
+  #    memory: 256Mi
+  #    cpu: 250m
   metrics:
-    enabled: true
+    enabled: false
+    serviceMonitor:
+      enabled: false
 
 memcached-blocks-metadata:
   # enabled/disabled via the tags.blocks-storage-memcached boolean
   architecture: "high-availability"
-  replicaCount: 2
+  replicaCount: 1
   # dpdbMinAvailable: 1
   # image: memcached:1.5.7-alpine
-  memcached:
-    maxItemMemory: 3840
-    extraArgs:
-      - -I 32m
-    threads: 32
+  command:
+    - /run.sh
+    - -m 256
+    - -I 32m
+    - -t 4
+  arguments: []
   resources: {}
   #  requests:
-  #    memory: 1Gi
-  #    cpu: 10m
+  #    memory: 256Mi
+  #    cpu: 250m
   #  limits:
-  #    memory: 4Gi
-  #    cpu: 1
+  #    memory: 256Mi
+  #    cpu: 250m
   metrics:
-    enabled: true
+    enabled: false
+    serviceMonitor:
+      enabled: false
 
 configsdb_postgresql:
   enabled: false


### PR DESCRIPTION
Signed-off-by: Thomas Bianchi <mail@thomasbianchi.it>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
3. Please do not edit/bump the Chart.yaml "version" field
-->

**What this PR does**:
edit values.yaml giving a working cortex instance configured with block storage, memcache and memberlist

**Which issue(s) this PR fixes**:
[N/A]

**Checklist**
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`

This is a proposal to update `values.yaml` giving a working instance with updated defaults.  
I tested with a kubernetes kind created simply by: `kind create cluster` and then `helm install  --create-namespace --namespace cortex -f values.yaml cortex .`, eventually every component start:

![image](https://user-images.githubusercontent.com/12055298/137917425-68939cca-5d1d-46a4-a445-230e7fcf7a77.png)

in depth:

- I configured a backend blocks by default on filesystem, we are using in our production environment gcp bucket storage, so I included the example for it ( it needs only two fields name and json ). 

```
  blocks-storage-memcached: true

  storage:
    engine: blocks
  blocks_storage:
    backend: "filesystem"
    filesystem:
      dir: "/data/blocks-storage"
    # backend: "gcs"
    # gcs:
    #   bucket_name: ""
    #   service_account: "" # json credentials
    bucket_store:
      sync_dir: "data"
      index_cache:
        backend: memcached
```
- The numbers in this section are taken partially from [this issue](https://github.com/thanos-io/thanos/issues/1979). I found that these defaults are better for a real environment without being too much.

```
       memcached:
          addresses: 'dns+{{ include "cortex.fullname" $ }}-memcached-blocks-index:11211'
          timeout: 300ms
          max_idle_connections: 750
          max_async_concurrency: 100
          max_async_buffer_size: 10000000
```
- Memberlist configuration instead of consul

```
    ring:
      kvstore:
        store: memberlist
```

- Decreased all components to 1 replica
- Memcached Chart do not have those values like extraArgs or maxItemMemory so I found out that this works:

```
memcached-frontend:
  enabled: true
  architecture: "high-availability"
  replicaCount: 1
  # dpdbMinAvailable: 1
  # image: memcached:1.5.7-alpine
  command:
    - /run.sh
    - -m 256
    - -I 32m
    - -t 4
  arguments: []
  resources: {}
  #  requests:
  #    memory: 256Mi
  #    cpu: 250m
  #  limits:
  #    memory: 256Mi
  #    cpu: 250m
  metrics:
    enabled: false
    serviceMonitor:
      enabled: false
```

We have been using Cortex in production environment for 8 months, with great results! I want to thank you all.
Our configuration is really similar to this proposal.

Some numbers:
![image](https://user-images.githubusercontent.com/12055298/137919616-c45bd5c5-4a07-48df-b5bd-dc6b6bce641d.png)
> I think would be useful insert in this repository a directory `cortex-mixin` with a collection of Grafana dashboard for monitoring cortex itself, I do not even remember where I found this dashboard...

![image](https://user-images.githubusercontent.com/12055298/137920482-53297662-431b-4f3d-af57-9f7dfc636ba8.png)
