### PR TITLE
pass distributer service type from values.yaml to support other service types like LoadBalancer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 * [BUGFIX] Fix nil pointer evaluation when using `ruler.dictonaries` option #242
 * [DEPENDENCY] Update Helm release memcached to v5.15.5 #241
 * [DEPENDENCY] Update Helm release memcached to v5.15.8 #247
+* [ENHANCEMENT] pass distributer service type from values.yaml to support other service types like LoadBalancer #254
+
 
 ## 0.7.0 / 2021-10-05
 

--- a/templates/distributor/distributor-svc.yaml
+++ b/templates/distributor/distributor-svc.yaml
@@ -11,7 +11,7 @@ metadata:
   annotations:
     {{- toYaml .Values.distributor.service.annotations | nindent 4 }}
 spec:
-  type: ClusterIP
+  type: {{ .Values.distributor.service.type }}
   ports:
     - port: {{ .Values.config.server.http_listen_port }}
       protocol: TCP

--- a/values.yaml
+++ b/values.yaml
@@ -401,6 +401,7 @@ distributor:
 
   service:
     annotations: {}
+    type: ClusterIP
     labels: {}
 
   serviceMonitor:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
3. Please do not edit/bump the Chart.yaml "version" field
-->

**What this PR does**:
enable users to override distributer service type
**Which issue(s) this PR fixes**:
Fixes #254

**Checklist**
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`