### PR TITLE
- Fixed hardcoding of containerSecurityContext in Ingester statefulset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,7 @@
 * [BUGFIX] Fix nil pointer evaluation when using `ruler.dictonaries` option #242
 * [DEPENDENCY] Update Helm release memcached to v5.15.5 #241
 * [DEPENDENCY] Update Helm release memcached to v5.15.8 #247
-* [BUGFIX] Fixed hardcoding of containerSecurityContext in Ingester statefulset
-* [BUGFIX] Brought setting of containerSecurityContext for the Ingester statefulset inline with other components configuration
+* [BUGFIX] Fixed hardcoding of containerSecurityContext in Ingester statefulset #258
 
 ## 0.7.0 / 2021-10-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@
 
 * [FEATURE] Add autoscaler for nginx #249
 * [BUGFIX] Fix nil pointer evaluation when using `ruler.dictonaries` option #242
+* [BUGFIX] Fixed hardcoding of containerSecurityContext in Ingester statefulset #258
 * [DEPENDENCY] Update Helm release memcached to v5.15.5 #241
 * [DEPENDENCY] Update Helm release memcached to v5.15.8 #247
-* [BUGFIX] Fixed hardcoding of containerSecurityContext in Ingester statefulset #258
 
 ## 0.7.0 / 2021-10-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 * [BUGFIX] Fix nil pointer evaluation when using `ruler.dictonaries` option #242
 * [DEPENDENCY] Update Helm release memcached to v5.15.5 #241
 * [DEPENDENCY] Update Helm release memcached to v5.15.8 #247
+* [BUGFIX] Fixed hardcoding of containerSecurityContext in Ingester statefulset
+* [BUGFIX] Brought setting of containerSecurityContext for the Ingester statefulset inline with other components configuration
 
 ## 0.7.0 / 2021-10-05
 

--- a/templates/ingester/ingester-statefulset.yaml
+++ b/templates/ingester/ingester-statefulset.yaml
@@ -150,8 +150,6 @@ spec:
             {{- toYaml .Values.ingester.readinessProbe | nindent 12 }}
           resources:
             {{- toYaml .Values.ingester.resources | nindent 12 }}
-          securityContext:
-            readOnlyRootFilesystem: true
           env:
             {{- if .Values.ingester.env }}
               {{- toYaml .Values.ingester.env | nindent 12 }}

--- a/templates/ingester/ingester-statefulset.yaml
+++ b/templates/ingester/ingester-statefulset.yaml
@@ -64,10 +64,9 @@ spec:
       {{- if .Values.ingester.priorityClassName }}
       priorityClassName: {{ .Values.ingester.priorityClassName }}
       {{- end }}
-      {{- if .Values.ingester.securityContext.enabled }}
-      securityContext:
-        {{- omit .Values.ingester.securityContext "enabled" | toYaml | nindent 8 }}
-      {{- end }}
+      {{ - if .Values.ingester.securityContext.enabled }}
+      securityContext: {{ - omit .Values.ingester.securityContext "enabled" | toYaml | nindent 8 }}
+      {{ - end }}
       initContainers:
         {{- toYaml .Values.ingester.initContainers | nindent 8 }}
       {{- if .Values.image.pullSecrets }}

--- a/templates/ingester/ingester-statefulset.yaml
+++ b/templates/ingester/ingester-statefulset.yaml
@@ -64,9 +64,9 @@ spec:
       {{- if .Values.ingester.priorityClassName }}
       priorityClassName: {{ .Values.ingester.priorityClassName }}
       {{- end }}
-      {{ - if .Values.ingester.securityContext.enabled }}
-      securityContext: {{ - omit .Values.ingester.securityContext "enabled" | toYaml | nindent 8 }}
-      {{ - end }}
+      {{- if .Values.ingester.securityContext.enabled }}
+      securityContext: {{- omit .Values.ingester.securityContext "enabled" | toYaml | nindent 8 }}
+      {{- end }}
       initContainers:
         {{- toYaml .Values.ingester.initContainers | nindent 8 }}
       {{- if .Values.image.pullSecrets }}

--- a/templates/ingester/ingester-statefulset.yaml
+++ b/templates/ingester/ingester-statefulset.yaml
@@ -150,6 +150,9 @@ spec:
             {{- toYaml .Values.ingester.readinessProbe | nindent 12 }}
           resources:
             {{- toYaml .Values.ingester.resources | nindent 12 }}
+          {{- if .Values.ingester.containerSecurityContext.enabled }}
+          securityContext: {{- omit .Values.ingester.containerSecurityContext "enabled" | toYaml | nindent 12 }}
+          {{- end }}
           env:
             {{- if .Values.ingester.env }}
               {{- toYaml .Values.ingester.env | nindent 12 }}


### PR DESCRIPTION
- Brought setting of containerSecurityContext for the Ingester statefulset inline with other components configuration

**What this PR does**:

- Removes the hardcoded value for containerSecurityContext in the ingester statefulset
- Brough the configuration of the ingester containerSecurityContext inline with what is documented in the values.

**Which issue(s) this PR fixes**:

Didn't raise an issue
