### PR TITLE
Don't create nginx resources unless nginx is enabled.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * [DEPENDENCY] Update Helm release memcached to v5.15.5 #241
 * [DEPENDENCY] Update Helm release memcached to v5.15.8 #247
 * [FEATURE] Add in lifecycle for querier, querier-frontend, and distributor #243
+* [BUGFIX] Don't create nginx resources unless nginx is enabled. #261
 
 ## 0.7.0 / 2021-10-05
 

--- a/templates/nginx/nginx-hpa.yaml
+++ b/templates/nginx/nginx-hpa.yaml
@@ -1,5 +1,5 @@
+{{- if and .Values.nginx.enabled .Values.nginx.autoscaling.enabled }}
 {{- with .Values.nginx.autoscaling -}}
-{{- if .enabled }}
 apiVersion: autoscaling/v2beta2
 kind: HorizontalPodAutoscaler
 metadata:

--- a/templates/nginx/nginx-poddisruptionbudget.yaml
+++ b/templates/nginx/nginx-poddisruptionbudget.yaml
@@ -1,4 +1,4 @@
-{{- if and (gt (int .Values.nginx.replicas) 1) (.Values.nginx.podDisruptionBudget) }}
+{{- if and (.Values.nginx.enabled) (gt (int .Values.nginx.replicas) 1) (.Values.nginx.podDisruptionBudget) }}
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
3. Please do not edit/bump the Chart.yaml "version" field
-->

**What this PR does**:

Skip nginx resources if `nginx.enabled` is false. I noticed that the chart was creating an nginx pod disruption budget even though I had set `nginx.enabled` to `false`.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`