### PR TITLE
Disable ingester liveness probes by default.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * [DEPENDENCY] Update Helm release memcached to v5.15.9 #273
 * [CHANGE] Enable bucket index by default #275
+* [CHANGE] Disable ingester liveness probes by default. #263
 
 ## 1.0.1 / 2021-11-26
 * [BUGFIX] alertmanager/ruler deployment: fix indentation #266

--- a/README.md
+++ b/README.md
@@ -367,9 +367,7 @@ Kubernetes: `^1.19.0-0`
 | ingester.&ZeroWidthSpace;extraVolumes | list | `[]` |  |
 | ingester.&ZeroWidthSpace;initContainers | list | `[]` |  |
 | ingester.&ZeroWidthSpace;lifecycle.&ZeroWidthSpace;preStop | object | `{"httpGet":{"path":"/ingester/shutdown","port":"http-metrics"}}` | The /shutdown preStop hook is recommended as part of the ingester scaledown process, but can be removed to optimize rolling restarts in instances that will never be scaled down or when using chunks storage with WAL disabled. https://cortexmetrics.io/docs/guides/ingesters-scaling-up-and-down/#scaling-down |
-| ingester.&ZeroWidthSpace;livenessProbe.&ZeroWidthSpace;httpGet.&ZeroWidthSpace;path | string | `"/ready"` |  |
-| ingester.&ZeroWidthSpace;livenessProbe.&ZeroWidthSpace;httpGet.&ZeroWidthSpace;port | string | `"http-metrics"` |  |
-| ingester.&ZeroWidthSpace;livenessProbe.&ZeroWidthSpace;httpGet.&ZeroWidthSpace;scheme | string | `"HTTP"` |  |
+| ingester.&ZeroWidthSpace;livenessProbe | object | `{}` | Liveness probes for ingesters are not recommended.  Ref: https://cortexmetrics.io/docs/guides/running-cortex-on-kubernetes/#take-extra-care-with-ingesters |
 | ingester.&ZeroWidthSpace;nodeSelector | object | `{}` |  |
 | ingester.&ZeroWidthSpace;persistentVolume.&ZeroWidthSpace;accessModes | list | `["ReadWriteOnce"]` | Ingester data Persistent Volume access modes Must match those of existing PV or dynamic provisioner Ref: http://kubernetes.io/docs/user-guide/persistent-volumes/ |
 | ingester.&ZeroWidthSpace;persistentVolume.&ZeroWidthSpace;annotations | object | `{}` | Ingester data Persistent Volume Claim annotations |

--- a/templates/ingester/ingester-dep.yaml
+++ b/templates/ingester/ingester-dep.yaml
@@ -87,8 +87,10 @@ spec:
               protocol: TCP
           startupProbe:
             {{- toYaml .Values.ingester.startupProbe | nindent 12 }}
+          {{- if .Values.ingester.livenessProbe }}
           livenessProbe:
             {{- toYaml .Values.ingester.livenessProbe | nindent 12 }}
+          {{- end }}
           readinessProbe:
             {{- toYaml .Values.ingester.readinessProbe | nindent 12 }}
           resources:

--- a/templates/ingester/ingester-statefulset.yaml
+++ b/templates/ingester/ingester-statefulset.yaml
@@ -139,8 +139,10 @@ spec:
               protocol: TCP
           startupProbe:
             {{- toYaml .Values.ingester.startupProbe | nindent 12 }}
+          {{- if .Values.ingester.livenessProbe }}
           livenessProbe:
             {{- toYaml .Values.ingester.livenessProbe | nindent 12 }}
+          {{- end}}
           readinessProbe:
             {{- toYaml .Values.ingester.readinessProbe | nindent 12 }}
           resources:

--- a/values.yaml
+++ b/values.yaml
@@ -530,11 +530,9 @@ ingester:
       path: /ready
       port: http-metrics
       scheme: HTTP
-  livenessProbe:
-    httpGet:
-      path: /ready
-      port: http-metrics
-      scheme: HTTP
+  # -- Liveness probes for ingesters are not recommended.
+  #  Ref: https://cortexmetrics.io/docs/guides/running-cortex-on-kubernetes/#take-extra-care-with-ingesters
+  livenessProbe: {}
   readinessProbe:
     httpGet:
       path: /ready


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
3. Please do not edit/bump the Chart.yaml "version" field
-->

**What this PR does**:

Based on cortex docs at
https://cortexmetrics.io/docs/guides/running-cortex-on-kubernetes/#take-extra-care-with-ingesters,
liveness probes for ingesters are not recommended: "We do not recommend
configuring a liveness probe on ingesters - killing them is a last resort and
should not be left to a machine."

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`