### PR TITLE
Optionally set service account per dep/statefulset.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * [DEPENDENCY] Update Helm release memcached to v5.15.9 #273
 * [CHANGE] Enable bucket index by default #275
 * [CHANGE] Disable ingester liveness probes by default. #263
+* [FEATURE] Allow different service accounts per dep/statefulset. #264
 
 ## 1.0.1 / 2021-11-26
 * [BUGFIX] alertmanager/ruler deployment: fix indentation #266

--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ Kubernetes: `^1.19.0-0`
 | alertmanager.&ZeroWidthSpace;securityContext | object | `{}` |  |
 | alertmanager.&ZeroWidthSpace;service.&ZeroWidthSpace;annotations | object | `{}` |  |
 | alertmanager.&ZeroWidthSpace;service.&ZeroWidthSpace;labels | object | `{}` |  |
+| alertmanager.&ZeroWidthSpace;serviceAccount.&ZeroWidthSpace;name | string | `""` | "" disables the individual serviceAccount and uses the global serviceAccount for that component |
 | alertmanager.&ZeroWidthSpace;serviceMonitor.&ZeroWidthSpace;additionalLabels | object | `{}` |  |
 | alertmanager.&ZeroWidthSpace;serviceMonitor.&ZeroWidthSpace;enabled | bool | `false` |  |
 | alertmanager.&ZeroWidthSpace;serviceMonitor.&ZeroWidthSpace;extraEndpointSpec | object | `{}` | Additional endpoint configuration https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#endpoint |
@@ -183,6 +184,7 @@ Kubernetes: `^1.19.0-0`
 | compactor.&ZeroWidthSpace;securityContext | object | `{}` |  |
 | compactor.&ZeroWidthSpace;service.&ZeroWidthSpace;annotations | object | `{}` |  |
 | compactor.&ZeroWidthSpace;service.&ZeroWidthSpace;labels | object | `{}` |  |
+| compactor.&ZeroWidthSpace;serviceAccount.&ZeroWidthSpace;name | string | `""` | "" disables the individual serviceAccount and uses the global serviceAccount for that component |
 | compactor.&ZeroWidthSpace;serviceMonitor.&ZeroWidthSpace;additionalLabels | object | `{}` |  |
 | compactor.&ZeroWidthSpace;serviceMonitor.&ZeroWidthSpace;enabled | bool | `false` |  |
 | compactor.&ZeroWidthSpace;serviceMonitor.&ZeroWidthSpace;extraEndpointSpec | object | `{}` | Additional endpoint configuration https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#endpoint |
@@ -271,6 +273,7 @@ Kubernetes: `^1.19.0-0`
 | configs.&ZeroWidthSpace;securityContext | object | `{}` |  |
 | configs.&ZeroWidthSpace;service.&ZeroWidthSpace;annotations | object | `{}` |  |
 | configs.&ZeroWidthSpace;service.&ZeroWidthSpace;labels | object | `{}` |  |
+| configs.&ZeroWidthSpace;serviceAccount.&ZeroWidthSpace;name | string | `""` | "" disables the individual serviceAccount and uses the global serviceAccount for that component |
 | configs.&ZeroWidthSpace;serviceMonitor.&ZeroWidthSpace;additionalLabels | object | `{}` |  |
 | configs.&ZeroWidthSpace;serviceMonitor.&ZeroWidthSpace;enabled | bool | `false` |  |
 | configs.&ZeroWidthSpace;serviceMonitor.&ZeroWidthSpace;extraEndpointSpec | object | `{}` | Additional endpoint configuration https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#endpoint |
@@ -325,6 +328,7 @@ Kubernetes: `^1.19.0-0`
 | distributor.&ZeroWidthSpace;securityContext | object | `{}` |  |
 | distributor.&ZeroWidthSpace;service.&ZeroWidthSpace;annotations | object | `{}` |  |
 | distributor.&ZeroWidthSpace;service.&ZeroWidthSpace;labels | object | `{}` |  |
+| distributor.&ZeroWidthSpace;serviceAccount.&ZeroWidthSpace;name | string | `""` | "" disables the individual serviceAccount and uses the global serviceAccount for that component |
 | distributor.&ZeroWidthSpace;serviceMonitor.&ZeroWidthSpace;additionalLabels | object | `{}` |  |
 | distributor.&ZeroWidthSpace;serviceMonitor.&ZeroWidthSpace;enabled | bool | `false` |  |
 | distributor.&ZeroWidthSpace;serviceMonitor.&ZeroWidthSpace;extraEndpointSpec | object | `{}` | Additional endpoint configuration https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#endpoint |
@@ -385,6 +389,7 @@ Kubernetes: `^1.19.0-0`
 | ingester.&ZeroWidthSpace;securityContext | object | `{}` |  |
 | ingester.&ZeroWidthSpace;service.&ZeroWidthSpace;annotations | object | `{}` |  |
 | ingester.&ZeroWidthSpace;service.&ZeroWidthSpace;labels | object | `{}` |  |
+| ingester.&ZeroWidthSpace;serviceAccount.&ZeroWidthSpace;name | string | `nil` |  |
 | ingester.&ZeroWidthSpace;serviceMonitor.&ZeroWidthSpace;additionalLabels | object | `{}` |  |
 | ingester.&ZeroWidthSpace;serviceMonitor.&ZeroWidthSpace;enabled | bool | `false` |  |
 | ingester.&ZeroWidthSpace;serviceMonitor.&ZeroWidthSpace;extraEndpointSpec | object | `{}` | Additional endpoint configuration https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#endpoint |
@@ -501,6 +506,7 @@ Kubernetes: `^1.19.0-0`
 | nginx.&ZeroWidthSpace;service.&ZeroWidthSpace;annotations | object | `{}` |  |
 | nginx.&ZeroWidthSpace;service.&ZeroWidthSpace;labels | object | `{}` |  |
 | nginx.&ZeroWidthSpace;service.&ZeroWidthSpace;type | string | `"ClusterIP"` |  |
+| nginx.&ZeroWidthSpace;serviceAccount.&ZeroWidthSpace;name | string | `""` | "" disables the individual serviceAccount and uses the global serviceAccount for that component |
 | nginx.&ZeroWidthSpace;startupProbe.&ZeroWidthSpace;failureThreshold | int | `10` |  |
 | nginx.&ZeroWidthSpace;startupProbe.&ZeroWidthSpace;httpGet.&ZeroWidthSpace;path | string | `"/healthz"` |  |
 | nginx.&ZeroWidthSpace;startupProbe.&ZeroWidthSpace;httpGet.&ZeroWidthSpace;port | string | `"http-metrics"` |  |
@@ -545,6 +551,7 @@ Kubernetes: `^1.19.0-0`
 | querier.&ZeroWidthSpace;securityContext | object | `{}` |  |
 | querier.&ZeroWidthSpace;service.&ZeroWidthSpace;annotations | object | `{}` |  |
 | querier.&ZeroWidthSpace;service.&ZeroWidthSpace;labels | object | `{}` |  |
+| querier.&ZeroWidthSpace;serviceAccount.&ZeroWidthSpace;name | string | `""` | "" disables the individual serviceAccount and uses the global serviceAccount for that component |
 | querier.&ZeroWidthSpace;serviceMonitor.&ZeroWidthSpace;additionalLabels | object | `{}` |  |
 | querier.&ZeroWidthSpace;serviceMonitor.&ZeroWidthSpace;enabled | bool | `false` |  |
 | querier.&ZeroWidthSpace;serviceMonitor.&ZeroWidthSpace;extraEndpointSpec | object | `{}` | Additional endpoint configuration https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#endpoint |
@@ -588,6 +595,7 @@ Kubernetes: `^1.19.0-0`
 | query_frontend.&ZeroWidthSpace;securityContext | object | `{}` |  |
 | query_frontend.&ZeroWidthSpace;service.&ZeroWidthSpace;annotations | object | `{}` |  |
 | query_frontend.&ZeroWidthSpace;service.&ZeroWidthSpace;labels | object | `{}` |  |
+| query_frontend.&ZeroWidthSpace;serviceAccount.&ZeroWidthSpace;name | string | `""` | "" disables the individual serviceAccount and uses the global serviceAccount for that component |
 | query_frontend.&ZeroWidthSpace;serviceMonitor.&ZeroWidthSpace;additionalLabels | object | `{}` |  |
 | query_frontend.&ZeroWidthSpace;serviceMonitor.&ZeroWidthSpace;enabled | bool | `false` |  |
 | query_frontend.&ZeroWidthSpace;serviceMonitor.&ZeroWidthSpace;extraEndpointSpec | object | `{}` | Additional endpoint configuration https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#endpoint |
@@ -628,6 +636,7 @@ Kubernetes: `^1.19.0-0`
 | ruler.&ZeroWidthSpace;securityContext | object | `{}` |  |
 | ruler.&ZeroWidthSpace;service.&ZeroWidthSpace;annotations | object | `{}` |  |
 | ruler.&ZeroWidthSpace;service.&ZeroWidthSpace;labels | object | `{}` |  |
+| ruler.&ZeroWidthSpace;serviceAccount.&ZeroWidthSpace;name | string | `""` | "" disables the individual serviceAccount and uses the global serviceAccount for that component |
 | ruler.&ZeroWidthSpace;serviceMonitor.&ZeroWidthSpace;additionalLabels | object | `{}` |  |
 | ruler.&ZeroWidthSpace;serviceMonitor.&ZeroWidthSpace;enabled | bool | `false` |  |
 | ruler.&ZeroWidthSpace;serviceMonitor.&ZeroWidthSpace;extraEndpointSpec | object | `{}` | Additional endpoint configuration https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#endpoint |
@@ -690,6 +699,7 @@ Kubernetes: `^1.19.0-0`
 | store_gateway.&ZeroWidthSpace;securityContext | object | `{}` |  |
 | store_gateway.&ZeroWidthSpace;service.&ZeroWidthSpace;annotations | object | `{}` |  |
 | store_gateway.&ZeroWidthSpace;service.&ZeroWidthSpace;labels | object | `{}` |  |
+| store_gateway.&ZeroWidthSpace;serviceAccount.&ZeroWidthSpace;name | string | `""` | "" disables the individual serviceAccount and uses the global serviceAccount for that component |
 | store_gateway.&ZeroWidthSpace;serviceMonitor.&ZeroWidthSpace;additionalLabels | object | `{}` |  |
 | store_gateway.&ZeroWidthSpace;serviceMonitor.&ZeroWidthSpace;enabled | bool | `false` |  |
 | store_gateway.&ZeroWidthSpace;serviceMonitor.&ZeroWidthSpace;extraEndpointSpec | object | `{}` | Additional endpoint configuration https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#endpoint |
@@ -729,6 +739,7 @@ Kubernetes: `^1.19.0-0`
 | table_manager.&ZeroWidthSpace;securityContext | object | `{}` |  |
 | table_manager.&ZeroWidthSpace;service.&ZeroWidthSpace;annotations | object | `{}` |  |
 | table_manager.&ZeroWidthSpace;service.&ZeroWidthSpace;labels | object | `{}` |  |
+| table_manager.&ZeroWidthSpace;serviceAccount.&ZeroWidthSpace;name | string | `""` | "" disables the individual serviceAccount and uses the global serviceAccount for that component |
 | table_manager.&ZeroWidthSpace;serviceMonitor.&ZeroWidthSpace;additionalLabels | object | `{}` |  |
 | table_manager.&ZeroWidthSpace;serviceMonitor.&ZeroWidthSpace;enabled | bool | `false` |  |
 | table_manager.&ZeroWidthSpace;serviceMonitor.&ZeroWidthSpace;extraEndpointSpec | object | `{}` | Additional endpoint configuration https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#endpoint |

--- a/templates/alertmanager/alertmanager-dep.yaml
+++ b/templates/alertmanager/alertmanager-dep.yaml
@@ -35,7 +35,7 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
-      serviceAccountName: {{ template "cortex.serviceAccountName" . }}
+      serviceAccountName: {{ .Values.alertmanager.serviceAccount.name | default (include "cortex.serviceAccountName" . ) }}
     {{- if .Values.alertmanager.priorityClassName }}
       priorityClassName: {{ .Values.alertmanager.priorityClassName }}
     {{- end }}

--- a/templates/alertmanager/alertmanager-statefulset.yaml
+++ b/templates/alertmanager/alertmanager-statefulset.yaml
@@ -58,7 +58,7 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
-      serviceAccountName: {{ template "cortex.serviceAccountName" . }}
+      serviceAccountName: {{ .Values.alertmanager.serviceAccount.name | default (include "cortex.serviceAccountName" . ) }}
       {{- if .Values.alertmanager.priorityClassName }}
       priorityClassName: {{ .Values.alertmanager.priorityClassName }}
       {{- end }}

--- a/templates/compactor/compactor-statefulset.yaml
+++ b/templates/compactor/compactor-statefulset.yaml
@@ -58,7 +58,7 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
-      serviceAccountName: {{ template "cortex.serviceAccountName" . }}
+      serviceAccountName: {{ .Values.compactor.serviceAccount.name | default (include "cortex.serviceAccountName" . ) }}
       {{- if .Values.compactor.priorityClassName }}
       priorityClassName: {{ .Values.compactor.priorityClassName }}
       {{- end }}

--- a/templates/configs/configs-dep.yaml
+++ b/templates/configs/configs-dep.yaml
@@ -32,7 +32,7 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
-      serviceAccountName: {{ template "cortex.serviceAccountName" . }}
+      serviceAccountName: {{ .Values.configs.serviceAccount.name | default (include "cortex.serviceAccountName" . ) }}
     {{- if .Values.configs.priorityClassName }}
       priorityClassName: {{ .Values.configs.priorityClassName }}
     {{- end }}

--- a/templates/distributor/distributor-dep.yaml
+++ b/templates/distributor/distributor-dep.yaml
@@ -35,7 +35,7 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
-      serviceAccountName: {{ template "cortex.serviceAccountName" . }}
+      serviceAccountName: {{ .Values.distributor.serviceAccount.name | default (include "cortex.serviceAccountName" . ) }}
       {{- if .Values.distributor.priorityClassName }}
       priorityClassName: {{ .Values.distributor.priorityClassName }}
       {{- end }}

--- a/templates/ingester/ingester-dep.yaml
+++ b/templates/ingester/ingester-dep.yaml
@@ -36,7 +36,7 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
-      serviceAccountName: {{ template "cortex.serviceAccountName" . }}
+      serviceAccountName: {{ .Values.ingester.serviceAccount.name | default (include "cortex.serviceAccountName" . ) }}
       {{- if .Values.ingester.priorityClassName }}
       priorityClassName: {{ .Values.ingester.priorityClassName }}
       {{- end }}

--- a/templates/ingester/ingester-statefulset.yaml
+++ b/templates/ingester/ingester-statefulset.yaml
@@ -60,7 +60,7 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
-      serviceAccountName: {{ template "cortex.serviceAccountName" . }}
+      serviceAccountName: {{ .Values.ingester.serviceAccount.name | default (include "cortex.serviceAccountName" . ) }}
       {{- if .Values.ingester.priorityClassName }}
       priorityClassName: {{ .Values.ingester.priorityClassName }}
       {{- end }}

--- a/templates/nginx/nginx-dep.yaml
+++ b/templates/nginx/nginx-dep.yaml
@@ -30,7 +30,7 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
-      serviceAccountName: {{ template "cortex.serviceAccountName" . }}
+      serviceAccountName: {{ .Values.nginx.serviceAccount.name | default (include "cortex.serviceAccountName" . ) }}
       {{- if .Values.nginx.priorityClassName }}
       priorityClassName: {{ .Values.nginx.priorityClassName }}
       {{- end }}

--- a/templates/querier/querier-dep.yaml
+++ b/templates/querier/querier-dep.yaml
@@ -33,7 +33,7 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
-      serviceAccountName: {{ template "cortex.serviceAccountName" . }}
+      serviceAccountName: {{ .Values.querier.serviceAccount.name | default (include "cortex.serviceAccountName" . ) }}
       {{- if .Values.querier.priorityClassName }}
       priorityClassName: {{ .Values.querier.priorityClassName }}
       {{- end }}

--- a/templates/query-frontend/query-frontend-dep.yaml
+++ b/templates/query-frontend/query-frontend-dep.yaml
@@ -31,7 +31,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
-      serviceAccountName: {{ template "cortex.serviceAccountName" . }}
+      serviceAccountName: {{ .Values.query_frontend.serviceAccount.name | default (include "cortex.serviceAccountName" . ) }}
       {{- if .Values.query_frontend.priorityClassName }}
       priorityClassName: {{ .Values.query_frontend.priorityClassName }}
       {{- end }}

--- a/templates/ruler/ruler-dep.yaml
+++ b/templates/ruler/ruler-dep.yaml
@@ -34,7 +34,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
-      serviceAccountName: {{ template "cortex.serviceAccountName" . }}
+      serviceAccountName: {{ .Values.ruler.serviceAccount.name | default (include "cortex.serviceAccountName" . ) }}
     {{- if .Values.ruler.priorityClassName }}
       priorityClassName: {{ .Values.ruler.priorityClassName }}
     {{- end }}

--- a/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/templates/store-gateway/store-gateway-statefulset.yaml
@@ -57,7 +57,7 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
-      serviceAccountName: {{ template "cortex.serviceAccountName" . }}
+      serviceAccountName: {{ .Values.store_gateway.serviceAccount.name | default (include "cortex.serviceAccountName" . ) }}
       {{- if .Values.store_gateway.priorityClassName }}
       priorityClassName: {{ .Values.store_gateway.priorityClassName }}
       {{- end }}

--- a/templates/table-manager/table-manager-dep.yaml
+++ b/templates/table-manager/table-manager-dep.yaml
@@ -32,7 +32,7 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
-      serviceAccountName: {{ template "cortex.serviceAccountName" . }}
+      serviceAccountName: {{ .Values.table_manager.serviceAccount.name | default (include "cortex.serviceAccountName" . ) }}
       {{- if .Values.table_manager.priorityClassName }}
       priorityClassName: {{ .Values.table_manager.priorityClassName }}
       {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -177,6 +177,10 @@ alertmanager:
     annotations: {}
     labels: {}
 
+  serviceAccount:
+    # -- "" disables the individual serviceAccount and uses the global serviceAccount for that component
+    name: ""
+
   serviceMonitor:
     enabled: false
     additionalLabels: {}
@@ -317,6 +321,10 @@ distributor:
     annotations: {}
     labels: {}
 
+  serviceAccount:
+    # -- "" disables the individual serviceAccount and uses the global serviceAccount for that component
+    name: ""
+
   serviceMonitor:
     enabled: false
     additionalLabels: {}
@@ -421,6 +429,9 @@ ingester:
   service:
     annotations: {}
     labels: {}
+
+  serviceAccount:
+    name:
 
   serviceMonitor:
     enabled: false
@@ -574,6 +585,10 @@ ruler:
     annotations: {}
     labels: {}
 
+  serviceAccount:
+    # -- "" disables the individual serviceAccount and uses the global serviceAccount for that component
+    name: ""
+
   serviceMonitor:
     enabled: false
     additionalLabels: {}
@@ -688,6 +703,10 @@ querier:
     annotations: {}
     labels: {}
 
+  serviceAccount:
+    # -- "" disables the individual serviceAccount and uses the global serviceAccount for that component
+    name: ""
+
   serviceMonitor:
     enabled: false
     additionalLabels: {}
@@ -786,6 +805,10 @@ query_frontend:
     annotations: {}
     labels: {}
 
+  serviceAccount:
+    # -- "" disables the individual serviceAccount and uses the global serviceAccount for that component
+    name: ""
+
   serviceMonitor:
     enabled: false
     additionalLabels: {}
@@ -872,6 +895,10 @@ table_manager:
     annotations: {}
     labels: {}
 
+  serviceAccount:
+    # -- "" disables the individual serviceAccount and uses the global serviceAccount for that component
+    name: ""
+
   serviceMonitor:
     enabled: false
     additionalLabels: {}
@@ -946,6 +973,10 @@ configs:
   service:
     annotations: {}
     labels: {}
+
+  serviceAccount:
+    # -- "" disables the individual serviceAccount and uses the global serviceAccount for that component
+    name: ""
 
   serviceMonitor:
     enabled: false
@@ -1064,6 +1095,10 @@ nginx:
     annotations: {}
     labels: {}
 
+  serviceAccount:
+    # -- "" disables the individual serviceAccount and uses the global serviceAccount for that component
+    name: ""
+
   resources: {}
 
   # -- Additional Cortex container arguments, e.g. log.level (debug, info, warn, error)
@@ -1139,6 +1174,10 @@ store_gateway:
   service:
     annotations: {}
     labels: {}
+
+  serviceAccount:
+    # -- "" disables the individual serviceAccount and uses the global serviceAccount for that component
+    name: ""
 
   serviceMonitor:
     enabled: false
@@ -1253,6 +1292,10 @@ compactor:
   service:
     annotations: {}
     labels: {}
+
+  serviceAccount:
+    # -- "" disables the individual serviceAccount and uses the global serviceAccount for that component
+    name: ""
 
   serviceMonitor:
     enabled: false


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
3. Please do not edit/bump the Chart.yaml "version" field
-->

**What this PR does**:

Different cortex components might require different cloud provider
permissions. When using gke workload identity, pod iam permissions are
managed by kubernetes service account. This patch allows operators to
use different service accounts for each deployment or statefulset to
support fine-grained control of iam permissions in this scenario.

**Which issue(s) this PR fixes**:
Fixes #251

**Checklist**
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`