### PR TITLE
Enable bucket index by default.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## master / unreleased
 
 * [DEPENDENCY] Update Helm release memcached to v5.15.9 #273
+* [CHANGE] Enable bucket index by default #275
 
 ## 1.0.1 / 2021-11-26
 * [BUGFIX] alertmanager/ruler deployment: fix indentation #266

--- a/README.md
+++ b/README.md
@@ -203,6 +203,7 @@ Kubernetes: `^1.19.0-0`
 | config.&ZeroWidthSpace;api.&ZeroWidthSpace;prometheus_http_prefix | string | `"/prometheus"` |  |
 | config.&ZeroWidthSpace;api.&ZeroWidthSpace;response_compression_enabled | bool | `true` | Use GZIP compression for API responses. Some endpoints serve large YAML or JSON blobs which can benefit from compression. |
 | config.&ZeroWidthSpace;auth_enabled | bool | `false` |  |
+| config.&ZeroWidthSpace;blocks_storage.&ZeroWidthSpace;bucket_store.&ZeroWidthSpace;bucket_index.&ZeroWidthSpace;enabled | bool | `true` |  |
 | config.&ZeroWidthSpace;blocks_storage.&ZeroWidthSpace;bucket_store.&ZeroWidthSpace;sync_dir | string | `"/data/tsdb-sync"` |  |
 | config.&ZeroWidthSpace;blocks_storage.&ZeroWidthSpace;tsdb.&ZeroWidthSpace;dir | string | `"/data/tsdb"` |  |
 | config.&ZeroWidthSpace;distributor.&ZeroWidthSpace;pool.&ZeroWidthSpace;health_check_ingesters | bool | `true` |  |

--- a/values.yaml
+++ b/values.yaml
@@ -94,6 +94,8 @@ config:
       dir: /data/tsdb
     bucket_store:
       sync_dir: /data/tsdb-sync
+      bucket_index:
+        enabled: true
   # -- https://cortexmetrics.io/docs/configuration/configuration-file/#store_gateway_config
   store_gateway:
     sharding_enabled: false


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
3. Please do not edit/bump the Chart.yaml "version" field
-->

**What this PR does**:

The cortex docs recommend enabling the bucket index for both the querier
and the store-gateway: https://cortexmetrics.io/docs/blocks-storage/production-tips/.

Any reason not to enable this by default?

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`