### PR TITLE
workaround for .Capabilities.APIVersions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * [CHANGE] Enable bucket index by default #275
 * [CHANGE] Disable ingester liveness probes by default. #263
 * [FEATURE] Allow different service accounts per dep/statefulset. #264
+* [BUGFIX] workaround for .Capabilities.APIVersions. #277
 
 ## 1.0.1 / 2021-11-26
 * [BUGFIX] alertmanager/ruler deployment: fix indentation #266

--- a/templates/alertmanager/alertmanager-poddisruptionbudget.yaml
+++ b/templates/alertmanager/alertmanager-poddisruptionbudget.yaml
@@ -1,5 +1,5 @@
 {{- if and (gt (int .Values.alertmanager.replicas) 1) (.Values.alertmanager.podDisruptionBudget) }}
-{{- if .Capabilities.APIVersions.Has "policy/v1"}}
+{{- if or (.Capabilities.APIVersions.Has "policy/v1/PodDisruptionBudget") (semverCompare ">=1.21" .Capabilities.KubeVersion.Version) }}
 apiVersion: policy/v1
 {{- else }}
 apiVersion: policy/v1beta1

--- a/templates/compactor/compactor-poddisruptionbudget.yaml
+++ b/templates/compactor/compactor-poddisruptionbudget.yaml
@@ -1,5 +1,5 @@
 {{- if and (gt (int .Values.compactor.replicas) 1) (.Values.compactor.podDisruptionBudget) }}
-{{- if .Capabilities.APIVersions.Has "policy/v1"}}
+{{- if or (.Capabilities.APIVersions.Has "policy/v1/PodDisruptionBudget") (semverCompare ">=1.21" .Capabilities.KubeVersion.Version) }}
 apiVersion: policy/v1
 {{- else }}
 apiVersion: policy/v1beta1

--- a/templates/configs/configs-poddisruptionbudget.yaml
+++ b/templates/configs/configs-poddisruptionbudget.yaml
@@ -1,5 +1,5 @@
 {{- if and (gt (int .Values.configs.replicas) 1) (.Values.configs.podDisruptionBudget) }}
-{{- if .Capabilities.APIVersions.Has "policy/v1"}}
+{{- if or (.Capabilities.APIVersions.Has "policy/v1/PodDisruptionBudget") (semverCompare ">=1.21" .Capabilities.KubeVersion.Version) }}
 apiVersion: policy/v1
 {{- else }}
 apiVersion: policy/v1beta1

--- a/templates/distributor/distributor-poddisruptionbudget.yaml
+++ b/templates/distributor/distributor-poddisruptionbudget.yaml
@@ -1,5 +1,5 @@
 {{- if and (gt (int .Values.distributor.replicas) 1) (.Values.distributor.podDisruptionBudget) }}
-{{- if .Capabilities.APIVersions.Has "policy/v1"}}
+{{- if or (.Capabilities.APIVersions.Has "policy/v1/PodDisruptionBudget") (semverCompare ">=1.21" .Capabilities.KubeVersion.Version) }}
 apiVersion: policy/v1
 {{- else }}
 apiVersion: policy/v1beta1

--- a/templates/ingester/ingester-poddisruptionbudget.yaml
+++ b/templates/ingester/ingester-poddisruptionbudget.yaml
@@ -1,5 +1,5 @@
 {{- if and (gt (int .Values.ingester.replicas) 1) (.Values.ingester.podDisruptionBudget) }}
-{{- if .Capabilities.APIVersions.Has "policy/v1"}}
+{{- if or (.Capabilities.APIVersions.Has "policy/v1/PodDisruptionBudget") (semverCompare ">=1.21" .Capabilities.KubeVersion.Version) }}
 apiVersion: policy/v1
 {{- else }}
 apiVersion: policy/v1beta1

--- a/templates/nginx/nginx-poddisruptionbudget.yaml
+++ b/templates/nginx/nginx-poddisruptionbudget.yaml
@@ -1,5 +1,5 @@
 {{- if and (.Values.nginx.enabled) (gt (int .Values.nginx.replicas) 1) (.Values.nginx.podDisruptionBudget) }}
-{{- if .Capabilities.APIVersions.Has "policy/v1"}}
+{{- if or (.Capabilities.APIVersions.Has "policy/v1/PodDisruptionBudget") (semverCompare ">=1.21" .Capabilities.KubeVersion.Version) }}
 apiVersion: policy/v1
 {{- else }}
 apiVersion: policy/v1beta1

--- a/templates/querier/querier-poddisruptionbudget.yaml
+++ b/templates/querier/querier-poddisruptionbudget.yaml
@@ -1,5 +1,5 @@
 {{- if and (gt (int .Values.querier.replicas) 1) (.Values.querier.podDisruptionBudget) }}
-{{- if .Capabilities.APIVersions.Has "policy/v1"}}
+{{- if or (.Capabilities.APIVersions.Has "policy/v1/PodDisruptionBudget") (semverCompare ">=1.21" .Capabilities.KubeVersion.Version) }}
 apiVersion: policy/v1
 {{- else }}
 apiVersion: policy/v1beta1

--- a/templates/query-frontend/query-poddisruptionbudget.yaml
+++ b/templates/query-frontend/query-poddisruptionbudget.yaml
@@ -1,5 +1,5 @@
 {{- if and (gt (int .Values.query_frontend.replicas) 1) (.Values.query_frontend.podDisruptionBudget) }}
-{{- if .Capabilities.APIVersions.Has "policy/v1"}}
+{{- if or (.Capabilities.APIVersions.Has "policy/v1/PodDisruptionBudget") (semverCompare ">=1.21" .Capabilities.KubeVersion.Version) }}
 apiVersion: policy/v1
 {{- else }}
 apiVersion: policy/v1beta1

--- a/templates/ruler/ruler-poddisruptionbudget.yaml
+++ b/templates/ruler/ruler-poddisruptionbudget.yaml
@@ -1,5 +1,5 @@
 {{- if and (gt (int .Values.ruler.replicas) 1) (.Values.ruler.podDisruptionBudget) }}
-{{- if .Capabilities.APIVersions.Has "policy/v1"}}
+{{- if or (.Capabilities.APIVersions.Has "policy/v1/PodDisruptionBudget") (semverCompare ">=1.21" .Capabilities.KubeVersion.Version) }}
 apiVersion: policy/v1
 {{- else }}
 apiVersion: policy/v1beta1

--- a/templates/store-gateway/store-gateway-poddisruptionbudget.yaml
+++ b/templates/store-gateway/store-gateway-poddisruptionbudget.yaml
@@ -1,5 +1,5 @@
 {{- if and (gt (int .Values.store_gateway.replicas) 1) (.Values.store_gateway.podDisruptionBudget) }}
-{{- if .Capabilities.APIVersions.Has "policy/v1"}}
+{{- if or (.Capabilities.APIVersions.Has "policy/v1/PodDisruptionBudget") (semverCompare ">=1.21" .Capabilities.KubeVersion.Version) }}
 apiVersion: policy/v1
 {{- else }}
 apiVersion: policy/v1beta1

--- a/templates/table-manager/table-manager-poddisruptionbudget.yaml
+++ b/templates/table-manager/table-manager-poddisruptionbudget.yaml
@@ -1,5 +1,5 @@
 {{- if and (gt (int .Values.table_manager.replicas) 1) (.Values.table_manager.podDisruptionBudget) }}
-{{- if .Capabilities.APIVersions.Has "policy/v1"}}
+{{- if or (.Capabilities.APIVersions.Has "policy/v1/PodDisruptionBudget") (semverCompare ">=1.21" .Capabilities.KubeVersion.Version) }}
 apiVersion: policy/v1
 {{- else }}
 apiVersion: policy/v1beta1


### PR DESCRIPTION
**What this PR does**:
#227 introduced `policy/v1` for PodDisruptionBudgets with a conditional based on `.Capabilities.APIVersions`: https://github.com/cortexproject/cortex-helm-chart/blob/ad6ebfd62c0bce22dab28f7898623edf6f19115e/templates/compactor/compactor-poddisruptionbudget.yaml#L2
By default, `helm template` [populates `.Capabilities.APIVersions` with all API versions known to Kubernetes](https://github.com/helm/helm/blob/5f74c0e17f2c6ec7b6f488969773c61802e3faff/pkg/chartutil/capabilities.go#L38) client-go v1.22. Many CD tools use this to render the template, then naively try to deploy to Kubernetes clusters that don't support `policy/v1`, such as v1.20 (e.g., https://github.com/argoproj/argo-cd/issues/7291). This results in error messages like `no matches for kind "PodDisruptionBudget" in version "policy/v1"`.

`helm template` provides a couple ways to hint a more specific set of API versions:
* `--api-versions` can explicitly append API versions to `.Capabilities.APIVersions`
* `--kube-version` can override `.Capabilities.KubeVersion`, but doesn't have any effect on `.Capabilities.APIVersions`
* `--validate` will interrogate Kubernetes to get an accurate list of API versions

Currently, this chart only works currently with `helm template --validate` and `helm install`.

This PR provides a workaround so that all three methods of hinting API version support to `helm template` work as expected. This should make it easier for users of naive CD tools to deploy this chart successfully.

Demo with various options:
```
% helm template . -s templates/distributor/distributor-poddisruptionbudget.yaml | grep apiVersion
apiVersion: policy/v1beta1
% helm template . -s templates/distributor/distributor-poddisruptionbudget.yaml --kube-version v1.20 | grep apiVersion
apiVersion: policy/v1beta1
% helm template . -s templates/distributor/distributor-poddisruptionbudget.yaml --kube-version v1.21 | grep apiVersion 
apiVersion: policy/v1
% helm template . -s templates/distributor/distributor-poddisruptionbudget.yaml --api-versions=policy/v1/PodDisruptionBudget | grep apiVersion
apiVersion: policy/v1
% helm template . -s templates/distributor/distributor-poddisruptionbudget.yaml --validate | grep apiVersion
apiVersion: policy/v1
```

**Checklist**
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`