### PR TITLE
use helper to populate policy api version

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -112,3 +112,14 @@ Create configuration for frontend memcached configuration
 - "-frontend.memcached.addresses=dns+{{ template "cortex.fullname" . }}-memcached-frontend.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:11211"
 {{- end -}}
 {{- end -}}
+
+{{/*
+Determine the policy api version
+*/}}
+{{- define "cortex.pdbVersion" -}}
+{{- if or (.Capabilities.APIVersions.Has "policy/v1/PodDisruptionBudget") (semverCompare ">=1.21" .Capabilities.KubeVersion.Version) -}}
+policy/v1
+{{- else -}}
+policy/v1beta1
+{{- end -}}
+{{- end -}}

--- a/templates/alertmanager/alertmanager-poddisruptionbudget.yaml
+++ b/templates/alertmanager/alertmanager-poddisruptionbudget.yaml
@@ -1,9 +1,5 @@
 {{- if and (gt (int .Values.alertmanager.replicas) 1) (.Values.alertmanager.podDisruptionBudget) }}
-{{- if or (.Capabilities.APIVersions.Has "policy/v1/PodDisruptionBudget") (semverCompare ">=1.21" .Capabilities.KubeVersion.Version) }}
-apiVersion: policy/v1
-{{- else }}
-apiVersion: policy/v1beta1
-{{- end }}
+apiVersion: {{ include "cortex.pdbVersion" . }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "cortex.alertmanagerFullname" . }}

--- a/templates/compactor/compactor-poddisruptionbudget.yaml
+++ b/templates/compactor/compactor-poddisruptionbudget.yaml
@@ -1,9 +1,5 @@
 {{- if and (gt (int .Values.compactor.replicas) 1) (.Values.compactor.podDisruptionBudget) }}
-{{- if or (.Capabilities.APIVersions.Has "policy/v1/PodDisruptionBudget") (semverCompare ">=1.21" .Capabilities.KubeVersion.Version) }}
-apiVersion: policy/v1
-{{- else }}
-apiVersion: policy/v1beta1
-{{- end }}
+apiVersion: {{ include "cortex.pdbVersion" . }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "cortex.compactorFullname" . }}

--- a/templates/configs/configs-poddisruptionbudget.yaml
+++ b/templates/configs/configs-poddisruptionbudget.yaml
@@ -1,9 +1,5 @@
 {{- if and (gt (int .Values.configs.replicas) 1) (.Values.configs.podDisruptionBudget) }}
-{{- if or (.Capabilities.APIVersions.Has "policy/v1/PodDisruptionBudget") (semverCompare ">=1.21" .Capabilities.KubeVersion.Version) }}
-apiVersion: policy/v1
-{{- else }}
-apiVersion: policy/v1beta1
-{{- end }}
+apiVersion: {{ include "cortex.pdbVersion" . }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "cortex.configsFullname" . }}

--- a/templates/distributor/distributor-poddisruptionbudget.yaml
+++ b/templates/distributor/distributor-poddisruptionbudget.yaml
@@ -1,9 +1,5 @@
 {{- if and (gt (int .Values.distributor.replicas) 1) (.Values.distributor.podDisruptionBudget) }}
-{{- if or (.Capabilities.APIVersions.Has "policy/v1/PodDisruptionBudget") (semverCompare ">=1.21" .Capabilities.KubeVersion.Version) }}
-apiVersion: policy/v1
-{{- else }}
-apiVersion: policy/v1beta1
-{{- end }}
+apiVersion: {{ include "cortex.pdbVersion" . }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "cortex.distributorFullname" . }}

--- a/templates/ingester/ingester-poddisruptionbudget.yaml
+++ b/templates/ingester/ingester-poddisruptionbudget.yaml
@@ -1,9 +1,5 @@
 {{- if and (gt (int .Values.ingester.replicas) 1) (.Values.ingester.podDisruptionBudget) }}
-{{- if or (.Capabilities.APIVersions.Has "policy/v1/PodDisruptionBudget") (semverCompare ">=1.21" .Capabilities.KubeVersion.Version) }}
-apiVersion: policy/v1
-{{- else }}
-apiVersion: policy/v1beta1
-{{- end }}
+apiVersion: {{ include "cortex.pdbVersion" . }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "cortex.ingesterFullname" . }}

--- a/templates/nginx/nginx-poddisruptionbudget.yaml
+++ b/templates/nginx/nginx-poddisruptionbudget.yaml
@@ -1,9 +1,5 @@
 {{- if and (.Values.nginx.enabled) (gt (int .Values.nginx.replicas) 1) (.Values.nginx.podDisruptionBudget) }}
-{{- if or (.Capabilities.APIVersions.Has "policy/v1/PodDisruptionBudget") (semverCompare ">=1.21" .Capabilities.KubeVersion.Version) }}
-apiVersion: policy/v1
-{{- else }}
-apiVersion: policy/v1beta1
-{{- end }}
+apiVersion: {{ include "cortex.pdbVersion" . }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "cortex.nginxFullname" . }}

--- a/templates/querier/querier-poddisruptionbudget.yaml
+++ b/templates/querier/querier-poddisruptionbudget.yaml
@@ -1,9 +1,5 @@
 {{- if and (gt (int .Values.querier.replicas) 1) (.Values.querier.podDisruptionBudget) }}
-{{- if or (.Capabilities.APIVersions.Has "policy/v1/PodDisruptionBudget") (semverCompare ">=1.21" .Capabilities.KubeVersion.Version) }}
-apiVersion: policy/v1
-{{- else }}
-apiVersion: policy/v1beta1
-{{- end }}
+apiVersion: {{ include "cortex.pdbVersion" . }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "cortex.querierFullname" . }}

--- a/templates/query-frontend/query-poddisruptionbudget.yaml
+++ b/templates/query-frontend/query-poddisruptionbudget.yaml
@@ -1,9 +1,5 @@
 {{- if and (gt (int .Values.query_frontend.replicas) 1) (.Values.query_frontend.podDisruptionBudget) }}
-{{- if or (.Capabilities.APIVersions.Has "policy/v1/PodDisruptionBudget") (semverCompare ">=1.21" .Capabilities.KubeVersion.Version) }}
-apiVersion: policy/v1
-{{- else }}
-apiVersion: policy/v1beta1
-{{- end }}
+apiVersion: {{ include "cortex.pdbVersion" . }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "cortex.queryFrontendFullname" . }}

--- a/templates/ruler/ruler-poddisruptionbudget.yaml
+++ b/templates/ruler/ruler-poddisruptionbudget.yaml
@@ -1,9 +1,5 @@
 {{- if and (gt (int .Values.ruler.replicas) 1) (.Values.ruler.podDisruptionBudget) }}
-{{- if or (.Capabilities.APIVersions.Has "policy/v1/PodDisruptionBudget") (semverCompare ">=1.21" .Capabilities.KubeVersion.Version) }}
-apiVersion: policy/v1
-{{- else }}
-apiVersion: policy/v1beta1
-{{- end }}
+apiVersion: {{ include "cortex.pdbVersion" . }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "cortex.rulerFullname" . }}

--- a/templates/store-gateway/store-gateway-poddisruptionbudget.yaml
+++ b/templates/store-gateway/store-gateway-poddisruptionbudget.yaml
@@ -1,9 +1,5 @@
 {{- if and (gt (int .Values.store_gateway.replicas) 1) (.Values.store_gateway.podDisruptionBudget) }}
-{{- if or (.Capabilities.APIVersions.Has "policy/v1/PodDisruptionBudget") (semverCompare ">=1.21" .Capabilities.KubeVersion.Version) }}
-apiVersion: policy/v1
-{{- else }}
-apiVersion: policy/v1beta1
-{{- end }}
+apiVersion: {{ include "cortex.pdbVersion" . }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "cortex.storeGatewayFullname" . }}

--- a/templates/table-manager/table-manager-poddisruptionbudget.yaml
+++ b/templates/table-manager/table-manager-poddisruptionbudget.yaml
@@ -1,9 +1,5 @@
 {{- if and (gt (int .Values.table_manager.replicas) 1) (.Values.table_manager.podDisruptionBudget) }}
-{{- if or (.Capabilities.APIVersions.Has "policy/v1/PodDisruptionBudget") (semverCompare ">=1.21" .Capabilities.KubeVersion.Version) }}
-apiVersion: policy/v1
-{{- else }}
-apiVersion: policy/v1beta1
-{{- end }}
+apiVersion: {{ include "cortex.pdbVersion" . }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "cortex.tableManagerFullname" . }}


### PR DESCRIPTION
This refactors the work from #277 so that the API version logic is only implemented once in a helper.

**Checklist**
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`

This is a refactor, no behavioral change, so I did not include it in the change log.