### PR TITLE
Added /api/prom/rules and /api/prom/api/v1/alerts endpoints to Nginx …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
   * config.querier.query_ingesters_within: 13h -> 0s (default)
   * config.querier.query_store_after: 12h -> 0s (default)
 * [ENHANCEMENT] Fix the indentation of memcached guide #309
+* [ENHANCEMENT] Added api endpoints for Grafana 8 unified alerting #291
 
 ## 1.2.0 / 2021-12-29
 

--- a/templates/nginx/nginx-config.yaml
+++ b/templates/nginx/nginx-config.yaml
@@ -98,8 +98,8 @@ data:
           proxy_pass      http://{{ template "cortex.fullname" . }}-alertmanager.{{ $rootDomain }}$request_uri;
         }
 
-        location ~ /api/prom/api/v1/alerts {
-          proxy_pass      http://{{ template "cortex.fullname" . }}-alertmanager.{{ $rootDomain }}$request_uri;
+        location = /api/prom/api/v1/alerts {
+          proxy_pass      http://{{ template "cortex.fullname" . }}-alertmanager.{{ $rootDomain }}/api/v1/alerts;
         }
 
         # Ruler Config

--- a/templates/nginx/nginx-config.yaml
+++ b/templates/nginx/nginx-config.yaml
@@ -98,12 +98,20 @@ data:
           proxy_pass      http://{{ template "cortex.fullname" . }}-alertmanager.{{ $rootDomain }}$request_uri;
         }
 
+        location ~ /api/prom/api/v1/alerts {
+          proxy_pass      http://{{ template "cortex.fullname" . }}-alertmanager.{{ $rootDomain }}$request_uri;
+        }
+
         # Ruler Config
         location ~ /api/v1/rules {
           proxy_pass      http://{{ template "cortex.fullname" . }}-ruler.{{ $rootDomain }}$request_uri;
         }
 
         location ~ /ruler/ring {
+          proxy_pass      http://{{ template "cortex.fullname" . }}-ruler.{{ $rootDomain }}$request_uri;
+        }
+
+        location ~ /api/prom/rules {
           proxy_pass      http://{{ template "cortex.fullname" . }}-ruler.{{ $rootDomain }}$request_uri;
         }
 


### PR DESCRIPTION
**What this PR does**:

Adds the following HTTP endpoints to the Nginx configuration
- `/api/prom/rules` -> Cortex Ruler
- `/api/prom/api/v1/alerts` -> Cortex Alertmanager

This endpoints are used by Grafana 8 unified alerting.

**Which issue(s) this PR fixes**:
Fixes #257 

**Checklist**
- [ ] `CHANGELOG.md` updated 