### PR TITLE
move from quay.io/kiwigrid/k8s-sidecar to omegavvweapon/kopf-k8s-side…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master / unreleased
 
+* [CHANGE] move from quay.io/kiwigrid/k8s-sidecar to omegavvweapon/kopf-k8s-sidecar image #302
+
 ## 1.2.0 / 2021-12-29
 
 * [CHANGE] Use port number for prometheus port annotations. #288

--- a/README.md
+++ b/README.md
@@ -135,8 +135,23 @@ Kubernetes: `^1.19.0-0`
 | alertmanager.&ZeroWidthSpace;serviceMonitor.&ZeroWidthSpace;extraEndpointSpec | object | `{}` | Additional endpoint configuration https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#endpoint |
 | alertmanager.&ZeroWidthSpace;serviceMonitor.&ZeroWidthSpace;metricRelabelings | list | `[]` |  |
 | alertmanager.&ZeroWidthSpace;serviceMonitor.&ZeroWidthSpace;relabelings | list | `[]` |  |
-| alertmanager.&ZeroWidthSpace;sidecar | object | `{"containerSecurityContext":{"enabled":true,"readOnlyRootFilesystem":true},"defaultFolderName":null,"enableUniqueFilenames":false,"enabled":false,"folder":"/data","folderAnnotation":null,"image":{"repository":"quay.io/kiwigrid/k8s-sidecar","sha":"","tag":"1.10.7"},"imagePullPolicy":"IfNotPresent","label":"cortex_alertmanager","labelValue":null,"resources":{},"searchNamespace":null,"skipTlsVerify":false,"watchMethod":null}` | Sidecars that collect the configmaps with specified label and stores the included files them into the respective folders |
-| alertmanager.&ZeroWidthSpace;sidecar.&ZeroWidthSpace;skipTlsVerify | bool | `false` | skipTlsVerify Set to true to skip tls verification for kube api calls |
+| alertmanager.&ZeroWidthSpace;sidecar.&ZeroWidthSpace;containerSecurityContext.&ZeroWidthSpace;enabled | bool | `true` |  |
+| alertmanager.&ZeroWidthSpace;sidecar.&ZeroWidthSpace;containerSecurityContext.&ZeroWidthSpace;readOnlyRootFilesystem | bool | `true` |  |
+| alertmanager.&ZeroWidthSpace;sidecar.&ZeroWidthSpace;defaultFolderName | string | `nil` | The default folder name, it will create a subfolder under the `folder` and put rules in there instead |
+| alertmanager.&ZeroWidthSpace;sidecar.&ZeroWidthSpace;enableUniqueFilenames | bool | `false` | A value of true will produce unique filenames to avoid issues when duplicate data keys exist between ConfigMaps and/or Secrets within the same or multiple Namespaces. |
+| alertmanager.&ZeroWidthSpace;sidecar.&ZeroWidthSpace;enabled | bool | `false` | Enable sidecar that collect the configmaps with specified label and stores the included files them into the respective folders |
+| alertmanager.&ZeroWidthSpace;sidecar.&ZeroWidthSpace;folder | string | `"/data"` | Folder where the files should be placed. |
+| alertmanager.&ZeroWidthSpace;sidecar.&ZeroWidthSpace;folderAnnotation | string | `nil` | The annotation the sidecar will look for in ConfigMaps and/or Secrets to override the destination folder for files. If the value is a relative path, it will be relative to FOLDER |
+| alertmanager.&ZeroWidthSpace;sidecar.&ZeroWidthSpace;image.&ZeroWidthSpace;repository | string | `"omegavveapon/kopf-k8s-sidecar"` |  |
+| alertmanager.&ZeroWidthSpace;sidecar.&ZeroWidthSpace;image.&ZeroWidthSpace;sha | string | `""` |  |
+| alertmanager.&ZeroWidthSpace;sidecar.&ZeroWidthSpace;image.&ZeroWidthSpace;tag | string | `"1.4.0"` |  |
+| alertmanager.&ZeroWidthSpace;sidecar.&ZeroWidthSpace;imagePullPolicy | string | `"IfNotPresent"` |  |
+| alertmanager.&ZeroWidthSpace;sidecar.&ZeroWidthSpace;label | string | `"cortex_alertmanager"` | Label that should be used for filtering |
+| alertmanager.&ZeroWidthSpace;sidecar.&ZeroWidthSpace;labelValue | string | `nil` | The value for the label you want to filter your resources on. Don't set a value to filter by any value |
+| alertmanager.&ZeroWidthSpace;sidecar.&ZeroWidthSpace;resources | object | `{}` |  |
+| alertmanager.&ZeroWidthSpace;sidecar.&ZeroWidthSpace;searchNamespace | string | `nil` | The Namespace(s) from which resources will be watched. For multiple namespaces, use a comma-separated string like "default,test". If not set or set to ALL, it will watch all Namespaces. |
+| alertmanager.&ZeroWidthSpace;sidecar.&ZeroWidthSpace;skipTlsVerify | bool | `false` | Set to true to skip tls verification for kube api calls |
+| alertmanager.&ZeroWidthSpace;sidecar.&ZeroWidthSpace;watchMethod | string | `nil` | Determines how kopf-k8s-sidecar will run. If WATCH it will run like like a normal operator forever. If LIST it will gather the matching configmaps and secrets currently present, write those files to the destination directory and die |
 | alertmanager.&ZeroWidthSpace;startupProbe.&ZeroWidthSpace;failureThreshold | int | `10` |  |
 | alertmanager.&ZeroWidthSpace;startupProbe.&ZeroWidthSpace;httpGet.&ZeroWidthSpace;path | string | `"/ready"` |  |
 | alertmanager.&ZeroWidthSpace;startupProbe.&ZeroWidthSpace;httpGet.&ZeroWidthSpace;port | string | `"http-metrics"` |  |
@@ -637,13 +652,23 @@ Kubernetes: `^1.19.0-0`
 | ruler.&ZeroWidthSpace;serviceMonitor.&ZeroWidthSpace;extraEndpointSpec | object | `{}` | Additional endpoint configuration https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#endpoint |
 | ruler.&ZeroWidthSpace;serviceMonitor.&ZeroWidthSpace;metricRelabelings | list | `[]` |  |
 | ruler.&ZeroWidthSpace;serviceMonitor.&ZeroWidthSpace;relabelings | list | `[]` |  |
-| ruler.&ZeroWidthSpace;sidecar | object | `{"containerSecurityContext":{"enabled":true,"readOnlyRootFilesystem":true},"defaultFolderName":null,"enableUniqueFilenames":false,"enabled":false,"folder":"/tmp/rules","folderAnnotation":null,"image":{"repository":"quay.io/kiwigrid/k8s-sidecar","sha":"","tag":"1.10.7"},"imagePullPolicy":"IfNotPresent","label":"cortex_rules","labelValue":null,"resources":{},"searchNamespace":null,"watchMethod":null}` | Sidecars that collect the configmaps with specified label and stores the included files them into the respective folders |
+| ruler.&ZeroWidthSpace;sidecar.&ZeroWidthSpace;containerSecurityContext.&ZeroWidthSpace;enabled | bool | `true` |  |
+| ruler.&ZeroWidthSpace;sidecar.&ZeroWidthSpace;containerSecurityContext.&ZeroWidthSpace;readOnlyRootFilesystem | bool | `true` |  |
 | ruler.&ZeroWidthSpace;sidecar.&ZeroWidthSpace;defaultFolderName | string | `nil` | The default folder name, it will create a subfolder under the `folder` and put rules in there instead |
-| ruler.&ZeroWidthSpace;sidecar.&ZeroWidthSpace;folder | string | `"/tmp/rules"` | folder in the pod that should hold the collected rules (unless `defaultFolderName` is set) |
-| ruler.&ZeroWidthSpace;sidecar.&ZeroWidthSpace;folderAnnotation | string | `nil` | If specified, the sidecar will look for annotation with this name to create folder and put graph here. You can use this parameter together with `provider.foldersFromFilesStructure`to annotate configmaps and create folder structure. |
+| ruler.&ZeroWidthSpace;sidecar.&ZeroWidthSpace;enableUniqueFilenames | bool | `false` | A value of true will produce unique filenames to avoid issues when duplicate data keys exist between ConfigMaps and/or Secrets within the same or multiple Namespaces. |
+| ruler.&ZeroWidthSpace;sidecar.&ZeroWidthSpace;enabled | bool | `false` | Enable sidecar that collect the configmaps with specified label and stores the included files them into the respective folders |
+| ruler.&ZeroWidthSpace;sidecar.&ZeroWidthSpace;folder | string | `"/tmp/rules"` | Folder where the files should be placed. |
+| ruler.&ZeroWidthSpace;sidecar.&ZeroWidthSpace;folderAnnotation | string | `nil` | The annotation the sidecar will look for in ConfigMaps and/or Secrets to override the destination folder for files. If the value is a relative path, it will be relative to FOLDER |
+| ruler.&ZeroWidthSpace;sidecar.&ZeroWidthSpace;image.&ZeroWidthSpace;repository | string | `"omegavveapon/kopf-k8s-sidecar"` |  |
+| ruler.&ZeroWidthSpace;sidecar.&ZeroWidthSpace;image.&ZeroWidthSpace;sha | string | `""` |  |
+| ruler.&ZeroWidthSpace;sidecar.&ZeroWidthSpace;image.&ZeroWidthSpace;tag | string | `"1.4.0"` |  |
+| ruler.&ZeroWidthSpace;sidecar.&ZeroWidthSpace;imagePullPolicy | string | `"IfNotPresent"` |  |
 | ruler.&ZeroWidthSpace;sidecar.&ZeroWidthSpace;label | string | `"cortex_rules"` | label that the configmaps with rules are marked with |
-| ruler.&ZeroWidthSpace;sidecar.&ZeroWidthSpace;labelValue | string | `nil` | value of label that the configmaps with rules are set to |
-| ruler.&ZeroWidthSpace;sidecar.&ZeroWidthSpace;searchNamespace | string | `nil` | If specified, the sidecar will search for rules config-maps inside this namespace. Otherwise the namespace in which the sidecar is running will be used. It's also possible to specify ALL to search in all namespaces |
+| ruler.&ZeroWidthSpace;sidecar.&ZeroWidthSpace;labelValue | string | `nil` | The value for the label you want to filter your resources on. Don't set a value to filter by any value |
+| ruler.&ZeroWidthSpace;sidecar.&ZeroWidthSpace;resources | object | `{}` |  |
+| ruler.&ZeroWidthSpace;sidecar.&ZeroWidthSpace;searchNamespace | string | `nil` | The Namespace(s) from which resources will be watched. For multiple namespaces, use a comma-separated string like "default,test". If not set or set to ALL, it will watch all Namespaces. |
+| ruler.&ZeroWidthSpace;sidecar.&ZeroWidthSpace;skipTlsVerify | bool | `false` | Set to true to skip tls verification for kube api calls |
+| ruler.&ZeroWidthSpace;sidecar.&ZeroWidthSpace;watchMethod | string | `nil` | Determines how kopf-k8s-sidecar will run. If WATCH it will run like like a normal operator forever. If LIST it will gather the matching configmaps and secrets currently present, write those files to the destination directory and die |
 | ruler.&ZeroWidthSpace;startupProbe.&ZeroWidthSpace;failureThreshold | int | `10` |  |
 | ruler.&ZeroWidthSpace;startupProbe.&ZeroWidthSpace;httpGet.&ZeroWidthSpace;path | string | `"/ready"` |  |
 | ruler.&ZeroWidthSpace;startupProbe.&ZeroWidthSpace;httpGet.&ZeroWidthSpace;port | string | `"http-metrics"` |  |

--- a/README.md
+++ b/README.md
@@ -137,21 +137,22 @@ Kubernetes: `^1.19.0-0`
 | alertmanager.&ZeroWidthSpace;serviceMonitor.&ZeroWidthSpace;relabelings | list | `[]` |  |
 | alertmanager.&ZeroWidthSpace;sidecar.&ZeroWidthSpace;containerSecurityContext.&ZeroWidthSpace;enabled | bool | `true` |  |
 | alertmanager.&ZeroWidthSpace;sidecar.&ZeroWidthSpace;containerSecurityContext.&ZeroWidthSpace;readOnlyRootFilesystem | bool | `true` |  |
-| alertmanager.&ZeroWidthSpace;sidecar.&ZeroWidthSpace;defaultFolderName | string | `nil` | The default folder name, it will create a subfolder under the `folder` and put rules in there instead |
+| alertmanager.&ZeroWidthSpace;sidecar.&ZeroWidthSpace;defaultFolderName | string | `""` | The default folder name, it will create a subfolder under the `folder` and put rules in there instead |
 | alertmanager.&ZeroWidthSpace;sidecar.&ZeroWidthSpace;enableUniqueFilenames | bool | `false` | A value of true will produce unique filenames to avoid issues when duplicate data keys exist between ConfigMaps and/or Secrets within the same or multiple Namespaces. |
 | alertmanager.&ZeroWidthSpace;sidecar.&ZeroWidthSpace;enabled | bool | `false` | Enable sidecar that collect the configmaps with specified label and stores the included files them into the respective folders |
 | alertmanager.&ZeroWidthSpace;sidecar.&ZeroWidthSpace;folder | string | `"/data"` | Folder where the files should be placed. |
-| alertmanager.&ZeroWidthSpace;sidecar.&ZeroWidthSpace;folderAnnotation | string | `nil` | The annotation the sidecar will look for in ConfigMaps and/or Secrets to override the destination folder for files. If the value is a relative path, it will be relative to FOLDER |
+| alertmanager.&ZeroWidthSpace;sidecar.&ZeroWidthSpace;folderAnnotation | string | `"k8s-sidecar-target-directory"` | The annotation the sidecar will look for in ConfigMaps and/or Secrets to override the destination folder for files. If the value is a relative path, it will be relative to FOLDER |
 | alertmanager.&ZeroWidthSpace;sidecar.&ZeroWidthSpace;image.&ZeroWidthSpace;repository | string | `"omegavveapon/kopf-k8s-sidecar"` |  |
 | alertmanager.&ZeroWidthSpace;sidecar.&ZeroWidthSpace;image.&ZeroWidthSpace;sha | string | `""` |  |
 | alertmanager.&ZeroWidthSpace;sidecar.&ZeroWidthSpace;image.&ZeroWidthSpace;tag | string | `"1.4.0"` |  |
 | alertmanager.&ZeroWidthSpace;sidecar.&ZeroWidthSpace;imagePullPolicy | string | `"IfNotPresent"` |  |
 | alertmanager.&ZeroWidthSpace;sidecar.&ZeroWidthSpace;label | string | `"cortex_alertmanager"` | Label that should be used for filtering |
-| alertmanager.&ZeroWidthSpace;sidecar.&ZeroWidthSpace;labelValue | string | `nil` | The value for the label you want to filter your resources on. Don't set a value to filter by any value |
+| alertmanager.&ZeroWidthSpace;sidecar.&ZeroWidthSpace;labelValue | string | `""` | The value for the label you want to filter your resources on. Don't set a value to filter by any value |
+| alertmanager.&ZeroWidthSpace;sidecar.&ZeroWidthSpace;resource | string | `"both"` | The resource type that the operator will filter for. Can be configmap, secret or both |
 | alertmanager.&ZeroWidthSpace;sidecar.&ZeroWidthSpace;resources | object | `{}` |  |
-| alertmanager.&ZeroWidthSpace;sidecar.&ZeroWidthSpace;searchNamespace | string | `nil` | The Namespace(s) from which resources will be watched. For multiple namespaces, use a comma-separated string like "default,test". If not set or set to ALL, it will watch all Namespaces. |
+| alertmanager.&ZeroWidthSpace;sidecar.&ZeroWidthSpace;searchNamespace | string | `""` | The Namespace(s) from which resources will be watched. For multiple namespaces, use a comma-separated string like "default,test". If not set or set to ALL, it will watch all Namespaces. |
 | alertmanager.&ZeroWidthSpace;sidecar.&ZeroWidthSpace;skipTlsVerify | bool | `false` | Set to true to skip tls verification for kube api calls |
-| alertmanager.&ZeroWidthSpace;sidecar.&ZeroWidthSpace;watchMethod | string | `nil` | Determines how kopf-k8s-sidecar will run. If WATCH it will run like like a normal operator forever. If LIST it will gather the matching configmaps and secrets currently present, write those files to the destination directory and die |
+| alertmanager.&ZeroWidthSpace;sidecar.&ZeroWidthSpace;watchMethod | string | `""` | Determines how kopf-k8s-sidecar will run. If WATCH it will run like a normal operator forever. If LIST it will gather the matching configmaps and secrets currently present, write those files to the destination directory and die |
 | alertmanager.&ZeroWidthSpace;startupProbe.&ZeroWidthSpace;failureThreshold | int | `10` |  |
 | alertmanager.&ZeroWidthSpace;startupProbe.&ZeroWidthSpace;httpGet.&ZeroWidthSpace;path | string | `"/ready"` |  |
 | alertmanager.&ZeroWidthSpace;startupProbe.&ZeroWidthSpace;httpGet.&ZeroWidthSpace;port | string | `"http-metrics"` |  |
@@ -654,21 +655,22 @@ Kubernetes: `^1.19.0-0`
 | ruler.&ZeroWidthSpace;serviceMonitor.&ZeroWidthSpace;relabelings | list | `[]` |  |
 | ruler.&ZeroWidthSpace;sidecar.&ZeroWidthSpace;containerSecurityContext.&ZeroWidthSpace;enabled | bool | `true` |  |
 | ruler.&ZeroWidthSpace;sidecar.&ZeroWidthSpace;containerSecurityContext.&ZeroWidthSpace;readOnlyRootFilesystem | bool | `true` |  |
-| ruler.&ZeroWidthSpace;sidecar.&ZeroWidthSpace;defaultFolderName | string | `nil` | The default folder name, it will create a subfolder under the `folder` and put rules in there instead |
+| ruler.&ZeroWidthSpace;sidecar.&ZeroWidthSpace;defaultFolderName | string | `""` | The default folder name, it will create a subfolder under the `folder` and put rules in there instead |
 | ruler.&ZeroWidthSpace;sidecar.&ZeroWidthSpace;enableUniqueFilenames | bool | `false` | A value of true will produce unique filenames to avoid issues when duplicate data keys exist between ConfigMaps and/or Secrets within the same or multiple Namespaces. |
 | ruler.&ZeroWidthSpace;sidecar.&ZeroWidthSpace;enabled | bool | `false` | Enable sidecar that collect the configmaps with specified label and stores the included files them into the respective folders |
 | ruler.&ZeroWidthSpace;sidecar.&ZeroWidthSpace;folder | string | `"/tmp/rules"` | Folder where the files should be placed. |
-| ruler.&ZeroWidthSpace;sidecar.&ZeroWidthSpace;folderAnnotation | string | `nil` | The annotation the sidecar will look for in ConfigMaps and/or Secrets to override the destination folder for files. If the value is a relative path, it will be relative to FOLDER |
+| ruler.&ZeroWidthSpace;sidecar.&ZeroWidthSpace;folderAnnotation | string | `"k8s-sidecar-target-directory"` | The annotation the sidecar will look for in ConfigMaps and/or Secrets to override the destination folder for files. If the value is a relative path, it will be relative to FOLDER |
 | ruler.&ZeroWidthSpace;sidecar.&ZeroWidthSpace;image.&ZeroWidthSpace;repository | string | `"omegavveapon/kopf-k8s-sidecar"` |  |
 | ruler.&ZeroWidthSpace;sidecar.&ZeroWidthSpace;image.&ZeroWidthSpace;sha | string | `""` |  |
 | ruler.&ZeroWidthSpace;sidecar.&ZeroWidthSpace;image.&ZeroWidthSpace;tag | string | `"1.4.0"` |  |
 | ruler.&ZeroWidthSpace;sidecar.&ZeroWidthSpace;imagePullPolicy | string | `"IfNotPresent"` |  |
 | ruler.&ZeroWidthSpace;sidecar.&ZeroWidthSpace;label | string | `"cortex_rules"` | label that the configmaps with rules are marked with |
-| ruler.&ZeroWidthSpace;sidecar.&ZeroWidthSpace;labelValue | string | `nil` | The value for the label you want to filter your resources on. Don't set a value to filter by any value |
+| ruler.&ZeroWidthSpace;sidecar.&ZeroWidthSpace;labelValue | string | `""` | The value for the label you want to filter your resources on. Don't set a value to filter by any value |
+| ruler.&ZeroWidthSpace;sidecar.&ZeroWidthSpace;resource | string | `"both"` | The resource type that the operator will filter for. Can be configmap, secret or both |
 | ruler.&ZeroWidthSpace;sidecar.&ZeroWidthSpace;resources | object | `{}` |  |
-| ruler.&ZeroWidthSpace;sidecar.&ZeroWidthSpace;searchNamespace | string | `nil` | The Namespace(s) from which resources will be watched. For multiple namespaces, use a comma-separated string like "default,test". If not set or set to ALL, it will watch all Namespaces. |
+| ruler.&ZeroWidthSpace;sidecar.&ZeroWidthSpace;searchNamespace | string | `""` | The Namespace(s) from which resources will be watched. For multiple namespaces, use a comma-separated string like "default,test". If not set or set to ALL, it will watch all Namespaces. |
 | ruler.&ZeroWidthSpace;sidecar.&ZeroWidthSpace;skipTlsVerify | bool | `false` | Set to true to skip tls verification for kube api calls |
-| ruler.&ZeroWidthSpace;sidecar.&ZeroWidthSpace;watchMethod | string | `nil` | Determines how kopf-k8s-sidecar will run. If WATCH it will run like like a normal operator forever. If LIST it will gather the matching configmaps and secrets currently present, write those files to the destination directory and die |
+| ruler.&ZeroWidthSpace;sidecar.&ZeroWidthSpace;watchMethod | string | `""` | Determines how kopf-k8s-sidecar will run. If WATCH it will run like a normal operator forever. If LIST it will gather the matching configmaps and secrets currently present, write those files to the destination directory and die |
 | ruler.&ZeroWidthSpace;startupProbe.&ZeroWidthSpace;failureThreshold | int | `10` |  |
 | ruler.&ZeroWidthSpace;startupProbe.&ZeroWidthSpace;httpGet.&ZeroWidthSpace;path | string | `"/ready"` |  |
 | ruler.&ZeroWidthSpace;startupProbe.&ZeroWidthSpace;httpGet.&ZeroWidthSpace;port | string | `"http-metrics"` |  |

--- a/docs/guides/configure_rules_via_sidecar.markdown
+++ b/docs/guides/configure_rules_via_sidecar.markdown
@@ -10,6 +10,14 @@ Cortex can be configured to use a sidecar container in the Ruler and AlertManage
 Put ConfigMaps into the specified namespace, and they are automatically detected and added as files to the Ruler and/or AlertManager containers, both of which are polling for changes on the filesystem and will make the new configurations go live dynamically.
 This feature is disabled by default. Here is a simple example:
 
+*Please not that this is only supported with the local or filesystem backend. Otherwise cortex will overwrite what the operator puts in the folder with what is in s3/gcs/azure/swift. Cortex does not 2-way sync the files*
+
+```yaml
+backend: "filesystem"
+```
+
+## Helm values config
+
 ```yaml
 ruler:
   sidecar:

--- a/templates/alertmanager/alertmanager-dep.yaml
+++ b/templates/alertmanager/alertmanager-dep.yaml
@@ -68,8 +68,10 @@ spec:
             {{- end }}
             - name: FOLDER
               value: "{{ .Values.alertmanager.sidecar.folder }}{{- with .Values.alertmanager.sidecar.defaultFolderName }}/{{ . }}{{- end }}"
+            {{- if .Values.alertmanager.sidecar.resource}}
             - name: RESOURCE
-              value: "both"
+              value: {{ quote .Values.alertmanager.sidecar.resource }}
+            {{- end }}
             {{- if .Values.alertmanager.sidecar.enableUniqueFilenames }}
             - name: UNIQUE_FILENAMES
               value: "{{ .Values.alertmanager.sidecar.enableUniqueFilenames }}"
@@ -85,7 +87,7 @@ spec:
             {{- if .Values.alertmanager.sidecar.folderAnnotation }}
             - name: FOLDER_ANNOTATION
               value: "{{ .Values.alertmanager.sidecar.folderAnnotation }}"
-          {{- end }}
+            {{- end }}
           resources:
             {{- toYaml .Values.alertmanager.sidecar.resources | nindent 12 }}
           {{- if .Values.alertmanager.sidecar.containerSecurityContext.enabled }}

--- a/templates/alertmanager/alertmanager-statefulset.yaml
+++ b/templates/alertmanager/alertmanager-statefulset.yaml
@@ -113,8 +113,10 @@ spec:
             {{- end }}
             - name: FOLDER
               value: "{{ .Values.alertmanager.sidecar.folder }}{{- with .Values.alertmanager.sidecar.defaultFolderName }}/{{ . }}{{- end }}"
+            {{- if .Values.alertmanager.sidecar.resource}}
             - name: RESOURCE
-              value: "both"
+              value: {{ quote .Values.alertmanager.sidecar.resource }}
+            {{- end }}
             {{- if .Values.alertmanager.sidecar.enableUniqueFilenames }}
             - name: UNIQUE_FILENAMES
               value: "{{ .Values.alertmanager.sidecar.enableUniqueFilenames }}"
@@ -130,7 +132,7 @@ spec:
             {{- if .Values.alertmanager.sidecar.folderAnnotation }}
             - name: FOLDER_ANNOTATION
               value: "{{ .Values.alertmanager.sidecar.folderAnnotation }}"
-          {{- end }}
+            {{- end }}
           resources:
             {{- toYaml .Values.alertmanager.sidecar.resources | nindent 12 }}
           {{- if .Values.alertmanager.sidecar.containerSecurityContext.enabled }}

--- a/templates/ruler/ruler-dep.yaml
+++ b/templates/ruler/ruler-dep.yaml
@@ -67,8 +67,10 @@ spec:
             {{- end }}
             - name: FOLDER
               value: "{{ .Values.ruler.sidecar.folder }}{{- with .Values.ruler.sidecar.defaultFolderName }}/{{ . }}{{- end }}"
+            {{- if .Values.ruler.sidecar.resource}}
             - name: RESOURCE
-              value: "both"
+              value: {{ quote .Values.ruler.sidecar.resource }}
+            {{- end }}
             {{- if .Values.ruler.sidecar.enableUniqueFilenames }}
             - name: UNIQUE_FILENAMES
               value: "{{ .Values.ruler.sidecar.enableUniqueFilenames }}"
@@ -84,7 +86,7 @@ spec:
             {{- if .Values.ruler.sidecar.folderAnnotation }}
             - name: FOLDER_ANNOTATION
               value: "{{ .Values.ruler.sidecar.folderAnnotation }}"
-          {{- end }}
+            {{- end }}
           resources:
             {{- toYaml .Values.ruler.sidecar.resources | nindent 12 }}
           {{- if .Values.ruler.containerSecurityContext.enabled }}

--- a/values.yaml
+++ b/values.yaml
@@ -308,24 +308,26 @@ alertmanager:
     enableUniqueFilenames: false
     # -- Label that should be used for filtering
     label: cortex_alertmanager
-    # -- Determines how kopf-k8s-sidecar will run. If WATCH it will run like like a normal operator forever.
+    # -- Determines how kopf-k8s-sidecar will run. If WATCH it will run like a normal operator forever.
     # If LIST it will gather the matching configmaps and secrets currently present,
     # write those files to the destination directory and die
-    watchMethod: null
+    watchMethod: ""
     # -- The value for the label you want to filter your resources on.
     # Don't set a value to filter by any value
-    labelValue: null
+    labelValue: ""
     # -- Folder where the files should be placed.
     folder: /data
     # -- The default folder name, it will create a subfolder under the `folder` and put rules in there instead
-    defaultFolderName: null
+    defaultFolderName: ""
     # -- The Namespace(s) from which resources will be watched.
     # For multiple namespaces, use a comma-separated string like "default,test".
     # If not set or set to ALL, it will watch all Namespaces.
-    searchNamespace: null
+    searchNamespace: ""
     # -- The annotation the sidecar will look for in ConfigMaps and/or Secrets to override the destination folder for files.
     # If the value is a relative path, it will be relative to FOLDER
-    folderAnnotation: null
+    folderAnnotation: "k8s-sidecar-target-directory"
+    # -- The resource type that the operator will filter for. Can be configmap, secret or both
+    resource: "both"
     containerSecurityContext:
       enabled: true
       readOnlyRootFilesystem: true
@@ -686,24 +688,26 @@ ruler:
     enableUniqueFilenames: false
     # -- label that the configmaps with rules are marked with
     label: cortex_rules
-    # -- Determines how kopf-k8s-sidecar will run. If WATCH it will run like like a normal operator forever.
+    # -- Determines how kopf-k8s-sidecar will run. If WATCH it will run like a normal operator forever.
     # If LIST it will gather the matching configmaps and secrets currently present,
     # write those files to the destination directory and die
-    watchMethod: null
+    watchMethod: ""
     # -- The value for the label you want to filter your resources on.
     # Don't set a value to filter by any value
-    labelValue: null
+    labelValue: ""
     # -- Folder where the files should be placed.
     folder: /tmp/rules
     # -- The default folder name, it will create a subfolder under the `folder` and put rules in there instead
-    defaultFolderName: null
+    defaultFolderName: ""
     # -- The Namespace(s) from which resources will be watched.
     # For multiple namespaces, use a comma-separated string like "default,test".
     # If not set or set to ALL, it will watch all Namespaces.
-    searchNamespace: null
+    searchNamespace: ""
     # -- The annotation the sidecar will look for in ConfigMaps and/or Secrets to override the destination folder for files.
     # If the value is a relative path, it will be relative to FOLDER
-    folderAnnotation: null
+    folderAnnotation: "k8s-sidecar-target-directory"
+    # -- The resource type that the operator will filter for. Can be configmap, secret or both
+    resource: "both"
     containerSecurityContext:
       enabled: true
       readOnlyRootFilesystem: true

--- a/values.yaml
+++ b/values.yaml
@@ -292,24 +292,39 @@ alertmanager:
   # -- Extra env variables to pass to the cortex container
   env: []
 
-  # -- Sidecars that collect the configmaps with specified label and stores the included files them into the respective folders
   sidecar:
+    # -- Enable sidecar that collect the configmaps with specified label and stores the included files them into the respective folders
+    enabled: false
     image:
-      repository: quay.io/kiwigrid/k8s-sidecar
-      tag: 1.10.7
+      repository: omegavveapon/kopf-k8s-sidecar
+      tag: 1.4.0
       sha: ""
     imagePullPolicy: IfNotPresent
     resources: {}
-    # -- skipTlsVerify Set to true to skip tls verification for kube api calls
+    # -- Set to true to skip tls verification for kube api calls
     skipTlsVerify: false
+    # -- A value of true will produce unique filenames to avoid issues when duplicate data keys exist between ConfigMaps
+    # and/or Secrets within the same or multiple Namespaces.
     enableUniqueFilenames: false
-    enabled: false
+    # -- Label that should be used for filtering
     label: cortex_alertmanager
+    # -- Determines how kopf-k8s-sidecar will run. If WATCH it will run like like a normal operator forever.
+    # If LIST it will gather the matching configmaps and secrets currently present,
+    # write those files to the destination directory and die
     watchMethod: null
+    # -- The value for the label you want to filter your resources on.
+    # Don't set a value to filter by any value
     labelValue: null
+    # -- Folder where the files should be placed.
     folder: /data
+    # -- The default folder name, it will create a subfolder under the `folder` and put rules in there instead
     defaultFolderName: null
+    # -- The Namespace(s) from which resources will be watched.
+    # For multiple namespaces, use a comma-separated string like "default,test".
+    # If not set or set to ALL, it will watch all Namespaces.
     searchNamespace: null
+    # -- The annotation the sidecar will look for in ConfigMaps and/or Secrets to override the destination folder for files.
+    # If the value is a relative path, it will be relative to FOLDER
     folderAnnotation: null
     containerSecurityContext:
       enabled: true
@@ -655,39 +670,39 @@ ruler:
   # -- allow configuring rules via configmap. ref: https://cortexproject.github.io/cortex-helm-chart/guides/configure_rules_via_configmap.html
   directories: {}
 
-  # -- Sidecars that collect the configmaps with specified label and stores the included files them into the respective folders
   sidecar:
+    # -- Enable sidecar that collect the configmaps with specified label and stores the included files them into the respective folders
+    enabled: false
     image:
-      repository: quay.io/kiwigrid/k8s-sidecar
-      tag: 1.10.7
+      repository: omegavveapon/kopf-k8s-sidecar
+      tag: 1.4.0
       sha: ""
     imagePullPolicy: IfNotPresent
     resources: {}
-    #   limits:
-    #     cpu: 100m
-    #     memory: 100Mi
-    #   requests:
-    #     cpu: 50m
-    #     memory: 50Mi
-    # skipTlsVerify Set to true to skip tls verification for kube api calls
-    # skipTlsVerify: true
+    # -- Set to true to skip tls verification for kube api calls
+    skipTlsVerify: false
+    # -- A value of true will produce unique filenames to avoid issues when duplicate data keys exist between ConfigMaps
+    # and/or Secrets within the same or multiple Namespaces.
     enableUniqueFilenames: false
-    enabled: false
     # -- label that the configmaps with rules are marked with
     label: cortex_rules
+    # -- Determines how kopf-k8s-sidecar will run. If WATCH it will run like like a normal operator forever.
+    # If LIST it will gather the matching configmaps and secrets currently present,
+    # write those files to the destination directory and die
     watchMethod: null
-    # -- value of label that the configmaps with rules are set to
+    # -- The value for the label you want to filter your resources on.
+    # Don't set a value to filter by any value
     labelValue: null
-    # -- folder in the pod that should hold the collected rules (unless `defaultFolderName` is set)
+    # -- Folder where the files should be placed.
     folder: /tmp/rules
     # -- The default folder name, it will create a subfolder under the `folder` and put rules in there instead
     defaultFolderName: null
-    # -- If specified, the sidecar will search for rules config-maps inside this namespace.
-    # Otherwise the namespace in which the sidecar is running will be used.
-    # It's also possible to specify ALL to search in all namespaces
+    # -- The Namespace(s) from which resources will be watched.
+    # For multiple namespaces, use a comma-separated string like "default,test".
+    # If not set or set to ALL, it will watch all Namespaces.
     searchNamespace: null
-    # -- If specified, the sidecar will look for annotation with this name to create folder and put graph here.
-    # You can use this parameter together with `provider.foldersFromFilesStructure`to annotate configmaps and create folder structure.
+    # -- The annotation the sidecar will look for in ConfigMaps and/or Secrets to override the destination folder for files.
+    # If the value is a relative path, it will be relative to FOLDER
     folderAnnotation: null
     containerSecurityContext:
       enabled: true


### PR DESCRIPTION
Switches the current used sidecar to use a "proper" kubernetes-style operator image

**What this PR does**:
See Comment [#219 ](https://github.com/cortexproject/cortex-helm-chart/pull/219#issuecomment-1005989208)

**Which issue(s) this PR fixes**:

**Checklist**
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`