### PR TITLE
rollback optimization from release 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@
 
 * [CHANGE] move from quay.io/kiwigrid/k8s-sidecar to omegavvweapon/kopf-k8s-sidecar image #302
 * [CHANGE] undo querier store optimization #304
-  * config.querier.query_ingesters_within: 13h -> 0s
-  * config.querier.query_store_after: 12h -> 0s
+  * config.querier.query_ingesters_within: 13h -> 0s (default)
+  * config.querier.query_store_after: 12h -> 0s (default)
 
 ## 1.2.0 / 2021-12-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## master / unreleased
 
 * [CHANGE] move from quay.io/kiwigrid/k8s-sidecar to omegavvweapon/kopf-k8s-sidecar image #302
+* [CHANGE] undo querier store optimization #304
+  * config.querier.query_ingesters_within: 13h -> 0s
+  * config.querier.query_store_after: 12h -> 0s
 
 ## 1.2.0 / 2021-12-29
 

--- a/README.md
+++ b/README.md
@@ -242,8 +242,6 @@ Kubernetes: `^1.19.0-0`
 | config.&ZeroWidthSpace;memberlist.&ZeroWidthSpace;bind_port | int | `7946` |  |
 | config.&ZeroWidthSpace;memberlist.&ZeroWidthSpace;join_members | list | `["{{ include \"cortex.fullname\" $ }}-memberlist"]` | the service name of the memberlist if using memberlist discovery |
 | config.&ZeroWidthSpace;querier.&ZeroWidthSpace;active_query_tracker_dir | string | `"/data/active-query-tracker"` |  |
-| config.&ZeroWidthSpace;querier.&ZeroWidthSpace;query_ingesters_within | string | `"0s"` | Maximum lookback beyond which queries are not sent to ingester. 0 means all queries are sent to ingester. |
-| config.&ZeroWidthSpace;querier.&ZeroWidthSpace;query_store_after | string | `"0s"` | The time after which a metric should be queried from storage and not just ingesters. |
 | config.&ZeroWidthSpace;querier.&ZeroWidthSpace;store_gateway_addresses | string | automatic | Comma separated list of store-gateway addresses in DNS Service Discovery format. This option should is set automatically when using the blocks storage and the store-gateway sharding is disabled (when enabled, the store-gateway instances form a ring and addresses are picked from the ring). |
 | config.&ZeroWidthSpace;query_range.&ZeroWidthSpace;align_queries_with_step | bool | `true` |  |
 | config.&ZeroWidthSpace;query_range.&ZeroWidthSpace;cache_results | bool | `true` |  |

--- a/README.md
+++ b/README.md
@@ -242,8 +242,8 @@ Kubernetes: `^1.19.0-0`
 | config.&ZeroWidthSpace;memberlist.&ZeroWidthSpace;bind_port | int | `7946` |  |
 | config.&ZeroWidthSpace;memberlist.&ZeroWidthSpace;join_members | list | `["{{ include \"cortex.fullname\" $ }}-memberlist"]` | the service name of the memberlist if using memberlist discovery |
 | config.&ZeroWidthSpace;querier.&ZeroWidthSpace;active_query_tracker_dir | string | `"/data/active-query-tracker"` |  |
-| config.&ZeroWidthSpace;querier.&ZeroWidthSpace;query_ingesters_within | string | `"13h"` | Maximum lookback beyond which queries are not sent to ingester. 0 means all queries are sent to ingester. Ingesters by default have no data older than 12 hours, so we can safely set this 13 hours |
-| config.&ZeroWidthSpace;querier.&ZeroWidthSpace;query_store_after | string | `"12h"` | The time after which a metric should be queried from storage and not just ingesters. |
+| config.&ZeroWidthSpace;querier.&ZeroWidthSpace;query_ingesters_within | string | `"0s"` | Maximum lookback beyond which queries are not sent to ingester. 0 means all queries are sent to ingester. |
+| config.&ZeroWidthSpace;querier.&ZeroWidthSpace;query_store_after | string | `"0s"` | The time after which a metric should be queried from storage and not just ingesters. |
 | config.&ZeroWidthSpace;querier.&ZeroWidthSpace;store_gateway_addresses | string | automatic | Comma separated list of store-gateway addresses in DNS Service Discovery format. This option should is set automatically when using the blocks storage and the store-gateway sharding is disabled (when enabled, the store-gateway instances form a ring and addresses are picked from the ring). |
 | config.&ZeroWidthSpace;query_range.&ZeroWidthSpace;align_queries_with_step | bool | `true` |  |
 | config.&ZeroWidthSpace;query_range.&ZeroWidthSpace;cache_results | bool | `true` |  |

--- a/values.yaml
+++ b/values.yaml
@@ -115,12 +115,11 @@ config:
   querier:
     active_query_tracker_dir: /data/active-query-tracker
     # -- Maximum lookback beyond which queries are not sent to ingester. 0 means all
-    # queries are sent to ingester. Ingesters by default have no data older than 12 hours,
-    # so we can safely set this 13 hours
-    query_ingesters_within: 13h
+    # queries are sent to ingester.
+    query_ingesters_within: 0s
     # -- The time after which a metric should be queried from storage and not just
     # ingesters.
-    query_store_after: 12h
+    query_store_after: 0s
     # -- Comma separated list of store-gateway addresses in DNS Service Discovery
     # format. This option should is set automatically when using the blocks storage and the
     # store-gateway sharding is disabled (when enabled, the store-gateway instances

--- a/values.yaml
+++ b/values.yaml
@@ -114,12 +114,6 @@ config:
       - '{{ include "cortex.fullname" $ }}-memberlist'
   querier:
     active_query_tracker_dir: /data/active-query-tracker
-    # -- Maximum lookback beyond which queries are not sent to ingester. 0 means all
-    # queries are sent to ingester.
-    query_ingesters_within: 0s
-    # -- The time after which a metric should be queried from storage and not just
-    # ingesters.
-    query_store_after: 0s
     # -- Comma separated list of store-gateway addresses in DNS Service Discovery
     # format. This option should is set automatically when using the blocks storage and the
     # store-gateway sharding is disabled (when enabled, the store-gateway instances


### PR DESCRIPTION
**What this PR does**:
Removes optimization from querier route logic and applies the default values. The values appear to be wrong to begin with and should have been:
```yaml
query_store_after: 6h
query_ingesters_within: 7h
```

but you actually have to calculate them to get decent values which is out of scope for this helm-chart. See [Production Tips](https://cortexmetrics.io/docs/blocks-storage/production-tips/#how-to-estimate--querierquery-store-after) on how to do that.

**Which issue(s) this PR fixes**:

**Checklist**
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`