### PR TITLE
Add guide for configuration am and ruler with mounted config maps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
   * config.querier.query_store_after: 12h -> 0s (default)
 * [ENHANCEMENT] Fix the indentation of memcached guide #309
 * [ENHANCEMENT] Added api endpoints for Grafana 8 unified alerting #291
+* [ENHANCEMENT] Add guide on how to configure alertmanager/ruler with configmap
 
 ## 1.2.0 / 2021-12-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
   * config.querier.query_store_after: 12h -> 0s (default)
 * [ENHANCEMENT] Fix the indentation of memcached guide #309
 * [ENHANCEMENT] Added api endpoints for Grafana 8 unified alerting #291
-* [ENHANCEMENT] Add guide on how to configure alertmanager/ruler with configmap
+* [ENHANCEMENT] Add guide on how to configure alertmanager/ruler with configmap #313
 
 ## 1.2.0 / 2021-12-29
 

--- a/docs/assets/scripts/copyCode.js
+++ b/docs/assets/scripts/copyCode.js
@@ -6,7 +6,7 @@ const template = `
 
 
 document.addEventListener("DOMContentLoaded", function () {
-  const codeBlocks = document.querySelectorAll('.highlighter-rouge');
+  const codeBlocks = document.querySelectorAll('div.highlighter-rouge');
   codeBlocks.forEach((codeBlock, index) => {
     const code = codeBlocks[index].innerText;
     const wrapper = document.createElement("div");

--- a/docs/guides/configure_ruler_and_alertmanager_with_configmap.markdown
+++ b/docs/guides/configure_ruler_and_alertmanager_with_configmap.markdown
@@ -1,0 +1,171 @@
+---
+layout: page
+title: Configure Ruler and Alertmanager with Configmap
+parent: Guides
+has_children: true
+has_toc: false
+---
+# Preface
+
+Cortex's Ruler and Alertmanager can be setup to use ConfigMaps to provide themselves with an configuration that can be dynamically updated.
+We simply put ConfigMaps into the same namespace where cortex is running, and they are automatically detected and mounted as files to the Ruler and/or AlertManager containers.
+The containers are also constantly polling for changes to the ConfigMaps. If any changes are found, the configuration file on the container will be updated.
+
+It should be noted that this guide is assuming that multi-tenancy is enabled :
+```yaml
+auth_enabled: true
+```
+
+# Setup
+
+In order to get this working, we must do a couple things
+
+## Create Ruler ConfigMap
+
+To provide the Ruler with the *rules* to alert on, we must create a ConfigMap with the desired ruleset. How you maintain and deploy the ConfigMap is completely in your control, the only requirement is that the ConfigMap be on the same namespace as the Ruler.
+
+**IMPORTANT** things to note
+
+- This ruleset is ONLY for tenantfoo (We will explicitly map it to tenantfoo later)
+- The section under `tenantfoo.yaml` is validated and interpreted exactly as a Prometheus rules configuration would be. How you configure this is completely up to you.
+
+```yaml
+kind: ConfigMap
+metadata:
+  name: tenantfoo-ruler-config
+  namespace: cortex
+apiVersion: v1
+data:
+  tenantfoo.yaml: |-
+    groups:
+      - name: <group name>
+        rules:
+          - alert: <alert name>
+            expr: <promql expression>
+            for: <duration>
+            labels:
+              severity: <severity>
+            annotations:
+              description: <description>
+          <remainder of alerts...>
+```
+
+## Create Alertmanager ConfigMap
+
+To provide the Alertmanager with the information needed to *route* notifications to stakeholders, we must create a ConfigMap with the desired routing rules. How you maintain and deploy the ConfigMap is completely in your control, the only requirement is that the ConfigMap be on the same namespace as the Alertmanager.
+
+**IMPORTANT** things to note
+
+- These routing rules are ONLY for tenantfoo. The Alertmanager takes the key under `data` (excluding `.yaml`) and uses it as the tenant name for that specific config.
+- The section under `tenantfoo.yaml` is validated and interpreted exactly as a Prometheus alerting rules configuration would be. How you configure this is completely up to you.
+
+```yaml
+kind: ConfigMap
+metadata:
+  name: tenantfoo-alertmanager-config
+  namespace: cortex
+apiVersion: v1
+data:
+  tenantfoo.yaml: |
+    global:
+      resolve_timeout: <duration>
+      http_config: {}
+      smtp_from: ExamplePerson <exampleperson@example.com>
+      smtp_hello: example.com
+      smtp_smarthost: example-smtp.example.com
+    route:
+      receiver: team-X-mails
+      group_by: ['alertname']
+      group_wait: <duration>
+      group_interval: <duration>
+      repeat_interval: <duration>
+    receivers:
+    - name: 'team-X-mails'
+      email_configs:
+      - to: 'example@example.com'
+```
+
+## Helm Chart Configuration
+
+Now that the ConfigMaps are created, we can tinker the helm chart to achieve our goal.
+
+### Configuraion For Ruler and Alertmanager Config
+Add this to the `values.yaml` under the `config` section as shown.
+
+```yaml
+config:
+  ruler:
+    enable_api: true
+    rule_path: /data/rules
+
+  ruler_storage:
+    backend: "local"
+    local:
+      directory: /rules
+
+  alertmanager:
+    enable_api: true
+    external_url: "/api/prom/alertmanager"
+    data_dir: /data/
+
+  alertmanager_storage:
+    backend: "local"
+    local:
+      path: /data
+```
+
+### Configuraion For Ruler and Alertmanager
+Add this to the `values.yaml`.
+Note that when we mount `tenantfoo-ruler-config`, we mount it under a folder which should be named after the tenant it corresponds to. In this situation, since we want `tenantfoo-ruler-config` to be the alerting rules for `tenantfoo`, we mount it under `/rules/tenantfoo`.
+Also note that for `tenantfoo-alertmanager-config`, we similarily mount it under a folder specific to that tenant. Although it will not use the folder name as the tenant name (it instead uses the key name under `data` in the ConfigMap), it simplifies things if you do so.
+
+```yaml
+ruler:
+  extraVolumes:
+    - configMap:
+        defaultMode: 420
+        name: tenantfoo-ruler-config
+      name: tenantfoo-ruler-config
+  extraVolumeMounts:
+    - name: tenantfoo-ruler-config
+      mountPath: /rules/tenantfoo
+alertmanager:
+  extraVolumes:
+    - configMap:
+        defaultMode: 420
+        name: tenantfoo-alertmanager-config
+      name: tenantfoo-alertmanager-config
+  extraVolumeMounts:
+    - name: alertmanager-config
+      mountPath: /data/tenantfoo
+```
+
+# Result
+
+You can now install the helm chart.
+
+You may use the section below to verify the configuration went according to plan.
+
+### Verify Alertmanager
+
+1. Port-forward the alertmanager pod
+2. Run `curl -X GET -H "X-Scope-OrgID: <name of tenant>" localhost:8080/api/v1/alerts`
+3. Verify the correct configuration shows up
+
+### Verify Ruler
+
+1. Port-forward the ruler pod
+2. Run `curl -X GET -H "X-Scope-OrgID: <name of tenant>" localhost:8080/api/v1/rules`
+3. Verify the correct configuration shows up
+
+# Moving forward
+
+You can also follow this guide if you don't have multi-tenancy enabled. However, in this case, you will not get alerting/routing rules specific to each tenant.
+
+Defining fine-grained alerting/routing rules per tenant is when you really get to eat the fruits of your labour when deploying multi-tenant alertmanager/ruler. For example, lets say you currently only have routing rules for tenantfoo. If you wanted to add specific routing rules for another tenant, tenantB, you will do the following:
+
+1. Create another set of ConfigMaps for the new tenants, being sure to adhere to the naming policies stated in this guide
+
+2. Add entries under `extraVolumes` and `extraVolumeMounts` for the Ruler and Alertmanager. All while being sure to adhere to the naming policies stated in this guide
+
+3. [Verify the new tenant is configured](#result)

--- a/docs/guides/configure_ruler_and_alertmanager_with_configmap.markdown
+++ b/docs/guides/configure_ruler_and_alertmanager_with_configmap.markdown
@@ -97,12 +97,12 @@ Add this to the `values.yaml` under the `config` section as shown.
 config:
   ruler:
     enable_api: true
-    rule_path: /data/rules
+    rule_path: /rules
 
   ruler_storage:
     backend: "local"
     local:
-      directory: /rules
+      directory: /data/rules
 
   alertmanager:
     enable_api: true
@@ -129,7 +129,7 @@ ruler:
       name: tenantfoo-ruler-config
   extraVolumeMounts:
     - name: tenantfoo-ruler-config
-      mountPath: /rules/tenantfoo
+      mountPath: /data/rules/tenantfoo
 alertmanager:
   extraVolumes:
     - configMap:

--- a/docs/guides/configure_ruler_and_alertmanager_with_configmap.markdown
+++ b/docs/guides/configure_ruler_and_alertmanager_with_configmap.markdown
@@ -7,7 +7,7 @@ has_toc: false
 ---
 # Preface
 
-Cortex's Ruler and Alertmanager can be setup to use ConfigMaps to provide themselves with an configuration that can be dynamically updated.
+Cortex's Ruler and Alertmanager can be setup to use ConfigMaps to provide themselves with a configuration that can be dynamically updated.
 We simply put ConfigMaps into the same namespace where cortex is running, and they are automatically detected and mounted as files to the Ruler and/or AlertManager containers.
 The containers are also constantly polling for changes to the ConfigMaps. If any changes are found, the configuration file on the container will be updated.
 
@@ -17,16 +17,16 @@ auth_enabled: true
 ```
 # Setup
 
-In order to get this working, we must do a couple things
+In order to get this working, we must do a couple things.
 
 ## Create Ruler ConfigMap
 
 To provide the Ruler with the *rules* to alert on, we must create a ConfigMap with the desired ruleset. How you maintain and deploy the ConfigMap is completely in your control, the only requirement is that the ConfigMap be on the same namespace as the Ruler.
 
-**IMPORTANT** things to note
+**IMPORTANT** things to note:
 
 - This ruleset is ONLY for tenantfoo (We will explicitly map it to tenantfoo later)
-- The section under `tenantfoo.yaml` is validated and interpreted exactly as a Prometheus rules configuration would be. How you configure this is completely up to you.
+- The section under `tenantfoo.yaml` is validated and interpreted exactly as a [Prometheus rules configuration](https://prometheus.io/docs/prometheus/latest/configuration/recording_rules/) would be. How you configure this is completely up to you.
 
 ```yaml
 kind: ConfigMap
@@ -53,10 +53,10 @@ data:
 
 To provide the Alertmanager with the information needed to *route* notifications to stakeholders, we must create a ConfigMap with the desired routing rules. How you maintain and deploy the ConfigMap is completely in your control, the only requirement is that the ConfigMap be on the same namespace as the Alertmanager.
 
-**IMPORTANT** things to note
+**IMPORTANT** things to note:
 
 - These routing rules are ONLY for tenantfoo. The Alertmanager takes the key under `data` (excluding `.yaml`) and uses it as the tenant name for that specific config.
-- The section under `tenantfoo.yaml` is validated and interpreted exactly as a Prometheus alerting rules configuration would be. How you configure this is completely up to you.
+- The section under `tenantfoo.yaml` is validated and interpreted exactly as a [Prometheus alerting rules configuration](https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules/) would be. How you configure this is completely up to you.
 
 ```yaml
 kind: ConfigMap

--- a/docs/guides/configure_ruler_and_alertmanager_with_configmap.markdown
+++ b/docs/guides/configure_ruler_and_alertmanager_with_configmap.markdown
@@ -55,9 +55,10 @@ data:
 To provide the Alertmanager with the information needed to *route* notifications to stakeholders, we must create a ConfigMap with the desired routing rules. How you maintain and deploy the ConfigMap is completely in your control, the only requirement is that the ConfigMap be on the same namespace as the Alertmanager.
 
 **IMPORTANT** things to note
-
+{% raw %}
 - These routing rules are ONLY for tenantfoo. The Alertmanager takes the key under `data` (excluding `.yaml`) and uses it as the tenant name for that specific config.
 - The section under `tenantfoo.yaml` is validated and interpreted exactly as a Prometheus alerting rules configuration would be. How you configure this is completely up to you.
+{% endraw %}
 
 ```yaml
 kind: ConfigMap
@@ -136,7 +137,7 @@ alertmanager:
         name: tenantfoo-alertmanager-config
       name: tenantfoo-alertmanager-config
   extraVolumeMounts:
-    - name: alertmanager-config
+    - name: tenantfoo-alertmanager-config
       mountPath: /data/tenantfoo
 ```
 

--- a/docs/guides/configure_ruler_and_alertmanager_with_configmap.markdown
+++ b/docs/guides/configure_ruler_and_alertmanager_with_configmap.markdown
@@ -2,7 +2,7 @@
 layout: page
 title: Configure Ruler and Alertmanager with Configmap
 parent: Guides
-has_children: true
+has_children: false
 has_toc: false
 ---
 # Preface
@@ -104,7 +104,6 @@ config:
 
   alertmanager:
     enable_api: true
-    external_url: "/api/prom/alertmanager"
     data_dir: /data/
 
   alertmanager_storage:
@@ -115,7 +114,7 @@ config:
 
 ### Configuraion For Ruler and Alertmanager
 Add this to the `values.yaml`.
-Note that when we mount `tenantfoo-ruler-config`, we mount it under a folder which should be named after the tenant it corresponds to. In this situation, since we want `tenantfoo-ruler-config` to be the alerting rules for `tenantfoo`, we mount it under `/rules/tenantfoo`.
+Note that when we mount `tenantfoo-ruler-config`, we mount it under a folder which should be named after the tenant it corresponds to. In this situation, since we want `tenantfoo-ruler-config` to be the alerting rules for `tenantfoo`, we mount it under `/data/rules/tenantfoo`.
 Also note that for `tenantfoo-alertmanager-config`, we similarily mount it under a folder specific to that tenant. Although it will not use the folder name as the tenant name (it instead uses the key name under `data` in the ConfigMap), it simplifies things if you do so.
 
 ```yaml

--- a/docs/guides/configure_ruler_and_alertmanager_with_configmap.markdown
+++ b/docs/guides/configure_ruler_and_alertmanager_with_configmap.markdown
@@ -15,7 +15,6 @@ It should be noted that this guide is assuming that multi-tenancy is enabled :
 ```yaml
 auth_enabled: true
 ```
-
 # Setup
 
 In order to get this working, we must do a couple things
@@ -55,10 +54,9 @@ data:
 To provide the Alertmanager with the information needed to *route* notifications to stakeholders, we must create a ConfigMap with the desired routing rules. How you maintain and deploy the ConfigMap is completely in your control, the only requirement is that the ConfigMap be on the same namespace as the Alertmanager.
 
 **IMPORTANT** things to note
-{% raw %}
+
 - These routing rules are ONLY for tenantfoo. The Alertmanager takes the key under `data` (excluding `.yaml`) and uses it as the tenant name for that specific config.
 - The section under `tenantfoo.yaml` is validated and interpreted exactly as a Prometheus alerting rules configuration would be. How you configure this is completely up to you.
-{% endraw %}
 
 ```yaml
 kind: ConfigMap

--- a/docs/guides/configure_ruler_and_alertmanager_with_configmap.markdown
+++ b/docs/guides/configure_ruler_and_alertmanager_with_configmap.markdown
@@ -26,7 +26,7 @@ To provide the Ruler with the *rules* to alert on, we must create a ConfigMap wi
 **IMPORTANT** things to note:
 
 - This ruleset is ONLY for tenantfoo (We will explicitly map it to tenantfoo later)
-- The section under `tenantfoo.yaml` is validated and interpreted exactly as a [Prometheus rules configuration](https://prometheus.io/docs/prometheus/latest/configuration/recording_rules/) would be. How you configure this is completely up to you.
+- The section under `tenantfoo.yaml` is validated and interpreted exactly as a [Prometheus rules configuration](https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules//) would be. How you configure this is completely up to you.
 
 ```yaml
 kind: ConfigMap
@@ -56,7 +56,7 @@ To provide the Alertmanager with the information needed to *route* notifications
 **IMPORTANT** things to note:
 
 - These routing rules are ONLY for tenantfoo. The Alertmanager takes the key under `data` (excluding `.yaml`) and uses it as the tenant name for that specific config.
-- The section under `tenantfoo.yaml` is validated and interpreted exactly as a [Prometheus alerting rules configuration](https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules/) would be. How you configure this is completely up to you.
+- The section under `tenantfoo.yaml` is validated and interpreted exactly as a [Prometheus alerting rules configuration](https://prometheus.io/docs/alerting/latest/configuration/) would be. How you configure this is completely up to you.
 
 ```yaml
 kind: ConfigMap


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
3. Please do not edit/bump the Chart.yaml "version" field
-->

Context: The documentation on how to setup and run Alertmanager/Ruler is quite difficult to follow and not comprehensive. Many people have been running into issues regarding the sidecar. In fact, I was advised by some folks who contribute regularly to `cortex` to actually avoid using the sidecar. For this reason, I chose to add a guide on how to setup the ruler and alertmanager simply with configmaps which mount onto the container itself.

**What this PR does**: Adds a guide on how to configure cortex alertmanager and ruler using configmaps mounted onto the containers


**Checklist**
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`