### PR TITLE
don't run ct test when nothing has changed

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -29,6 +29,14 @@ jobs:
         with:
           version: v3.4.0
 
+      - name: Run chart-testing (list-changed)
+        id: list-changed
+        run: |
+          changed=$(ct list-changed)
+          if [[ -n "$changed" ]]; then
+            echo "::set-output name=changed::true"
+          fi
+
       - name: Run chart-testing (lint)
         run: ct lint --config ct.yaml
 
@@ -39,8 +47,11 @@ jobs:
 
       - name: Create kind cluster
         uses: helm/kind-action@v1.2.0
+        if: steps.list-changed.outputs.changed == 'true'
 
       - name: Run chart-testing (install)
         run: |
           kubectl create namespace cortex
           ct install --config ct.yaml --namespace cortex
+        if: steps.list-changed.outputs.changed == 'true'
+


### PR DESCRIPTION
Signed-off-by: nschad <niclas.schad@gmail.com>

**What this PR does**:
Prevents the pipeline from running chart testing test for non chart related changes

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`