### PR TITLE
Fix permissions on AlertManager sidecar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## master / unreleased
+* [BUGFIX] AlertManager sidecar was changed to not run as user 0 which broke the sidecar
 
 ## 1.3.0 / 2022-02-10
 

--- a/values.yaml
+++ b/values.yaml
@@ -323,6 +323,7 @@ alertmanager:
     resource: "both"
     containerSecurityContext:
       enabled: true
+      runAsUser: 0
       readOnlyRootFilesystem: true
 
 distributor:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
3. Please do not edit/bump the Chart.yaml "version" field
-->

**What this PR does**:
This restores the user that the alertmanager sidecar runs as to 0. It had been changed during this refactor in https://github.com/cortexproject/cortex-helm-chart/pull/227/files for the 1.0.0 release:
```
-    securityContext:
-      runAsUser: 0
+    containerSecurityContext:
+      enabled: true
+      readOnlyRootFilesystem: true
```

**Which issue(s) this PR fixes**:
Fixes https://cloud-native.slack.com/archives/CCYDASBLP/p1642492446058600

**Checklist**
- [x ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`