### PR TITLE
Make alertmanager config optional in nginx.conf 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## master / unreleased
 
 * [ENHANCEMENT] Includes enable flags for each component #319
-* [ENHANCEMENT] Exclude cortex components endpoint when disabled from nginx config #326
+* [ENHANCEMENT] Exclude cortex components endpoint from nginx config when disabled #326
 
 ## 1.3.0 / 2022-02-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 * [ENHANCEMENT] Includes enable flags for each component #319
 
+## 1.3.1 / 2022-03-01
+
+* [ENHANCEMENT] Make altermanager config optional in nginx config #325
+
 ## 1.3.0 / 2022-02-10
 
 * [CHANGE] move from quay.io/kiwigrid/k8s-sidecar to omegavvweapon/kopf-k8s-sidecar image #302
@@ -39,8 +43,8 @@
 * [BUGFIX] alertmanager/ruler deployment: fix indentation #266
 
 ## 1.0.0 / 2021-11-25
-### This Release includes BREAKING CHANGES
 
+### This Release includes BREAKING CHANGES
 
 * [FEATURE] Add autoscaler for nginx #249
 * [FEATURE] Add in lifecycle for querier, querier-frontend, and distributor #243

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## master / unreleased
 
 * [ENHANCEMENT] Includes enable flags for each component #319
-* [ENHANCEMENT] Make altermanager config optional in nginx config #325
+* [ENHANCEMENT] Make altermanager,distributor,rules and config.config configurations optional in nginx config #325
 
 ## 1.3.0 / 2022-02-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## master / unreleased
 
 * [ENHANCEMENT] Includes enable flags for each component #319
-* [ENHANCEMENT] Make altermanager,distributor,rules and config.config configurations optional in nginx config #325
+* [ENHANCEMENT] Exclude cortex components endpoint when disabled from nginx config #325
 
 ## 1.3.0 / 2022-02-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,6 @@
 ## master / unreleased
 
 * [ENHANCEMENT] Includes enable flags for each component #319
-
-## 1.3.1 / 2022-03-01
-
 * [ENHANCEMENT] Make altermanager config optional in nginx config #325
 
 ## 1.3.0 / 2022-02-10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## master / unreleased
 
 * [ENHANCEMENT] Includes enable flags for each component #319
-* [ENHANCEMENT] Exclude cortex components endpoint when disabled from nginx config #325
+* [ENHANCEMENT] Exclude cortex components endpoint when disabled from nginx config #326
 
 ## 1.3.0 / 2022-02-10
 

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: 1.3.1
+version: 1.3.0
 appVersion: v1.11.0
 description: 'Horizontally scalable, highly available, multi-tenant, long term Prometheus.'
 home: https://cortexmetrics.io/

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: 1.3.0
+version: 1.3.1
 appVersion: v1.11.0
 description: 'Horizontally scalable, highly available, multi-tenant, long term Prometheus.'
 home: https://cortexmetrics.io/

--- a/templates/nginx/nginx-config.yaml
+++ b/templates/nginx/nginx-config.yaml
@@ -127,10 +127,14 @@ data:
 
         {{- end }}
 
+        {{- if .Values.configs.enabled }}
+
         # Config Config
         location ~ /api/prom/configs/.* {
           proxy_pass      http://{{ template "cortex.fullname" . }}-configs.{{ $rootDomain }}$request_uri;
         }
+
+        {{- end }}
 
         {{- if .Values.query_frontend.enabled }}
 

--- a/templates/nginx/nginx-config.yaml
+++ b/templates/nginx/nginx-config.yaml
@@ -67,6 +67,8 @@ data:
           return 200 'alive';
         }
 
+        {{- if .Values.distributor.enabled }}
+
         # Distributor Config
         location = /ring {
           proxy_pass      http://{{ template "cortex.fullname" . }}-distributor.{{ $rootDomain }}$request_uri;
@@ -84,6 +86,8 @@ data:
         location = /api/v1/push {
           proxy_pass      http://{{ template "cortex.fullname" . }}-distributor.{{ $rootDomain }}$request_uri;
         }
+
+        {{- end }}
 
         {{- if .Values.alertmanager.enabled }}
 
@@ -106,6 +110,8 @@ data:
 
         {{- end }}
 
+        {{- if .Values.ruler.enabled }}
+
         # Ruler Config
         location ~ /api/v1/rules {
           proxy_pass      http://{{ template "cortex.fullname" . }}-ruler.{{ $rootDomain }}$request_uri;
@@ -119,10 +125,14 @@ data:
           proxy_pass      http://{{ template "cortex.fullname" . }}-ruler.{{ $rootDomain }}$request_uri;
         }
 
+        {{- end }}
+
         # Config Config
         location ~ /api/prom/configs/.* {
           proxy_pass      http://{{ template "cortex.fullname" . }}-configs.{{ $rootDomain }}$request_uri;
         }
+
+        {{- if .Values.query_frontend.enabled }}
 
         # Query Config
         location ~ /api/prom/.* {
@@ -137,6 +147,9 @@ data:
         location ~ {{.Values.config.api.prometheus_http_prefix}}/api/v1/label/.* {
           proxy_pass      http://{{ template "cortex.fullname" . }}-query-frontend.{{ $rootDomain }}$request_uri;
         }
+
+        {{- end }}
+
         {{- if and (.Values.config.auth_enabled) (.Values.nginx.config.auth_orgs) }}
         # Auth orgs
         {{- range $org := compact .Values.nginx.config.auth_orgs | uniq }}

--- a/templates/nginx/nginx-config.yaml
+++ b/templates/nginx/nginx-config.yaml
@@ -85,6 +85,8 @@ data:
           proxy_pass      http://{{ template "cortex.fullname" . }}-distributor.{{ $rootDomain }}$request_uri;
         }
 
+        {{- if .Values.alertmanager.enabled }}
+
         # Alertmanager Config
         location ~ /api/prom/alertmanager/.* {
           proxy_pass      http://{{ template "cortex.fullname" . }}-alertmanager.{{ $rootDomain }}$request_uri;
@@ -101,6 +103,8 @@ data:
         location = /api/prom/api/v1/alerts {
           proxy_pass      http://{{ template "cortex.fullname" . }}-alertmanager.{{ $rootDomain }}/api/v1/alerts;
         }
+
+        {{- end }}
 
         # Ruler Config
         location ~ /api/v1/rules {


### PR DESCRIPTION
**What this PR does**:
Optionally allows for alertmanager section of nginx.conf to not be included based upon the `alertermanager.enabled` flag.

**Which issue(s) this PR fixes**:
Fixes #325 
