### PR TITLE
unable nginx keepalive to cortex components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * [ENHANCEMENT] Upgrade to Cortex v1.11.1 #331
 * [ENHANCEMENT] Includes enable flags for each component #319
 * [ENHANCEMENT] Exclude cortex components endpoint from nginx config when disabled #326
+* [ENHANCEMENT] Enable keepalive from nginx to cortex components #330
 
 ## 1.3.0 / 2022-02-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * [FEATURE] Add Query-Scheduler #268
 * [ENHANCEMENT] Allow StoreGateway podManagementPolicy to be changed #332
+* [ENHANCEMENT] Improve load-balancing to cortex components via nginx pod #330
 * [BUGFIX] Correct a typo in enabling distributor HPA #334
 * [BUGFIX] Frontend memcached address did not match the Service #337
 * [BUGFIX] Add service discovery method for query-scheduler addresses #338
@@ -13,7 +14,6 @@
 * [ENHANCEMENT] Upgrade to Cortex v1.11.1 #331
 * [ENHANCEMENT] Includes enable flags for each component #319
 * [ENHANCEMENT] Exclude cortex components endpoint from nginx config when disabled #326
-* [ENHANCEMENT] Enable keepalive from nginx to cortex components #330
 
 ## 1.3.0 / 2022-02-10
 

--- a/README.md
+++ b/README.md
@@ -488,6 +488,7 @@ Kubernetes: `^1.19.0-0`
 | nginx.&ZeroWidthSpace;config.&ZeroWidthSpace;mainSnippet | string | `""` | arbitrary snippet to inject in the top section of the nginx config |
 | nginx.&ZeroWidthSpace;config.&ZeroWidthSpace;serverSnippet | string | `""` | arbitrary snippet to inject in the server { } section of the nginx config |
 | nginx.&ZeroWidthSpace;config.&ZeroWidthSpace;setHeaders | object | `{}` |  |
+| nginx.&ZeroWidthSpace;config.&ZeroWidthSpace;upstream_keepalive | int | `16` | (optional) Maximum number of idle keepalive connections to upstream servers for each worker |
 | nginx.&ZeroWidthSpace;containerSecurityContext.&ZeroWidthSpace;enabled | bool | `true` |  |
 | nginx.&ZeroWidthSpace;containerSecurityContext.&ZeroWidthSpace;readOnlyRootFilesystem | bool | `false` |  |
 | nginx.&ZeroWidthSpace;enabled | bool | `true` |  |

--- a/templates/nginx/nginx-config.yaml
+++ b/templates/nginx/nginx-config.yaml
@@ -40,35 +40,35 @@ data:
       {{- if .Values.alertmanager.enabled }}
       upstream alertmanager {
         server {{ template "cortex.fullname" . }}-alertmanager.{{ $rootDomain }};
-        keepalive {{ .Values.nginx.config.upstream_keepalive }};
+        keepalive_timeout 0;
       }
       {{- end }}
 
       {{- if .Values.configs.enabled }}
       upstream configs {
         server {{ template "cortex.fullname" . }}-configs.{{ $rootDomain }};
-        keepalive {{ .Values.nginx.config.upstream_keepalive }};
+        keepalive_timeout 0;
       }
       {{- end }}
 
       {{- if .Values.distributor.enabled }}
       upstream distributor {
         server {{ template "cortex.fullname" . }}-distributor.{{ $rootDomain }};
-        keepalive {{ .Values.nginx.config.upstream_keepalive }};
+        keepalive_timeout 0;
       }
       {{- end }}
 
       {{- if .Values.query_frontend.enabled }}
       upstream query-frontend {
         server {{ template "cortex.fullname" . }}-query-frontend.{{ $rootDomain }};
-        keepalive {{ .Values.nginx.config.upstream_keepalive }};
+        keepalive_timeout 0;
       }
       {{- end }}
 
       {{- if .Values.ruler.enabled }}
       upstream ruler {
         server {{ template "cortex.fullname" . }}-ruler.{{ $rootDomain }};
-        keepalive {{ .Values.nginx.config.upstream_keepalive }};
+        keepalive_timeout 0;
       }
       {{- end }}
 
@@ -78,7 +78,6 @@ data:
         proxy_send_timeout 300s;
         proxy_read_timeout 300s;
         proxy_http_version 1.1;
-        proxy_set_header Connection "";  ## Enable keepalive to upstreams
 
         {{- range $key, $value := .Values.nginx.config.setHeaders }}
         proxy_set_header {{ $key }} {{ $value }};

--- a/templates/nginx/nginx-config.yaml
+++ b/templates/nginx/nginx-config.yaml
@@ -37,12 +37,48 @@ data:
       {{ tpl . $ | nindent 6 }}
       {{- end }}
 
+      {{- if .Values.alertmanager.enabled }}
+      upstream alertmanager {
+        server {{ template "cortex.fullname" . }}-alertmanager.{{ $rootDomain }};
+        keepalive {{ .Values.nginx.config.upstream_keepalive }};
+      }
+      {{- end }}
+
+      {{- if .Values.configs.enabled }}
+      upstream configs {
+        server {{ template "cortex.fullname" . }}-configs.{{ $rootDomain }};
+        keepalive {{ .Values.nginx.config.upstream_keepalive }};
+      }
+      {{- end }}
+
+      {{- if .Values.distributor.enabled }}
+      upstream distributor {
+        server {{ template "cortex.fullname" . }}-distributor.{{ $rootDomain }};
+        keepalive {{ .Values.nginx.config.upstream_keepalive }};
+      }
+      {{- end }}
+
+      {{- if .Values.query_frontend.enabled }}
+      upstream query-frontend {
+        server {{ template "cortex.fullname" . }}-query-frontend.{{ $rootDomain }};
+        keepalive {{ .Values.nginx.config.upstream_keepalive }};
+      }
+      {{- end }}
+
+      {{- if .Values.ruler.enabled }}
+      upstream ruler {
+        server {{ template "cortex.fullname" . }}-ruler.{{ $rootDomain }};
+        keepalive {{ .Values.nginx.config.upstream_keepalive }};
+      }
+      {{- end }}
+
       server { # simple reverse-proxy
         listen {{ .Values.nginx.http_listen_port }};
         proxy_connect_timeout 300s;
         proxy_send_timeout 300s;
         proxy_read_timeout 300s;
         proxy_http_version 1.1;
+        proxy_set_header Connection "";  ## Enable keepalive to upstreams
 
         {{- range $key, $value := .Values.nginx.config.setHeaders }}
         proxy_set_header {{ $key }} {{ $value }};
@@ -71,20 +107,20 @@ data:
 
         # Distributor Config
         location = /ring {
-          proxy_pass      http://{{ template "cortex.fullname" . }}-distributor.{{ $rootDomain }}$request_uri;
+          proxy_pass      http://distributor$request_uri;
         }
 
         location = /all_user_stats {
-          proxy_pass      http://{{ template "cortex.fullname" . }}-distributor.{{ $rootDomain }}$request_uri;
+          proxy_pass      http://distributor$request_uri;
         }
 
         location = /api/prom/push {
-          proxy_pass      http://{{ template "cortex.fullname" . }}-distributor.{{ $rootDomain }}$request_uri;
+          proxy_pass      http://distributor$request_uri;
         }
 
         ## New Remote write API. Ref: https://cortexmetrics.io/docs/api/#remote-write
         location = /api/v1/push {
-          proxy_pass      http://{{ template "cortex.fullname" . }}-distributor.{{ $rootDomain }}$request_uri;
+          proxy_pass      http://distributor$request_uri;
         }
 
         {{- end }}
@@ -93,19 +129,19 @@ data:
 
         # Alertmanager Config
         location ~ /api/prom/alertmanager/.* {
-          proxy_pass      http://{{ template "cortex.fullname" . }}-alertmanager.{{ $rootDomain }}$request_uri;
+          proxy_pass      http://alertmanager$request_uri;
         }
 
         location ~ /api/v1/alerts {
-          proxy_pass      http://{{ template "cortex.fullname" . }}-alertmanager.{{ $rootDomain }}$request_uri;
+          proxy_pass      http://alertmanager$request_uri;
         }
 
         location ~ /multitenant_alertmanager/status {
-          proxy_pass      http://{{ template "cortex.fullname" . }}-alertmanager.{{ $rootDomain }}$request_uri;
+          proxy_pass      http://alertmanager$request_uri;
         }
 
         location = /api/prom/api/v1/alerts {
-          proxy_pass      http://{{ template "cortex.fullname" . }}-alertmanager.{{ $rootDomain }}/api/v1/alerts;
+          proxy_pass      http://alertmanager/api/v1/alerts;
         }
 
         {{- end }}
@@ -114,15 +150,15 @@ data:
 
         # Ruler Config
         location ~ /api/v1/rules {
-          proxy_pass      http://{{ template "cortex.fullname" . }}-ruler.{{ $rootDomain }}$request_uri;
+          proxy_pass      http://ruler$request_uri;
         }
 
         location ~ /ruler/ring {
-          proxy_pass      http://{{ template "cortex.fullname" . }}-ruler.{{ $rootDomain }}$request_uri;
+          proxy_pass      http://ruler$request_uri;
         }
 
         location ~ /api/prom/rules {
-          proxy_pass      http://{{ template "cortex.fullname" . }}-ruler.{{ $rootDomain }}$request_uri;
+          proxy_pass      http://ruler$request_uri;
         }
 
         {{- end }}
@@ -131,7 +167,7 @@ data:
 
         # Config Config
         location ~ /api/prom/configs/.* {
-          proxy_pass      http://{{ template "cortex.fullname" . }}-configs.{{ $rootDomain }}$request_uri;
+          proxy_pass      http://configs$request_uri;
         }
 
         {{- end }}
@@ -140,16 +176,16 @@ data:
 
         # Query Config
         location ~ /api/prom/.* {
-          proxy_pass      http://{{ template "cortex.fullname" . }}-query-frontend.{{ $rootDomain }}$request_uri;
+          proxy_pass      http://query-frontend$request_uri;
         }
 
         ## New Query frontend APIs as per https://cortexmetrics.io/docs/api/#querier--query-frontend
         location ~ ^{{.Values.config.api.prometheus_http_prefix}}/api/v1/(read|metadata|labels|series|query_range|query) {
-          proxy_pass      http://{{ template "cortex.fullname" . }}-query-frontend.{{ $rootDomain }}$request_uri;
+          proxy_pass      http://query-frontend$request_uri;
         }
 
         location ~ {{.Values.config.api.prometheus_http_prefix}}/api/v1/label/.* {
-          proxy_pass      http://{{ template "cortex.fullname" . }}-query-frontend.{{ $rootDomain }}$request_uri;
+          proxy_pass      http://query-frontend$request_uri;
         }
 
         {{- end }}
@@ -159,7 +195,7 @@ data:
         {{- range $org := compact .Values.nginx.config.auth_orgs | uniq }}
         location = /api/v1/push/{{ $org }} {
           proxy_set_header      X-Scope-OrgID {{ $org }};
-          proxy_pass      http://{{ template "cortex.fullname" $ }}-distributor.{{ $rootDomain }}/api/v1/push;
+          proxy_pass      http://distributor/api/v1/push;
         }
         {{- end }}
         {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -1162,8 +1162,6 @@ nginx:
     setHeaders: {}
     # -- (optional) List of [auth tenants](https://cortexmetrics.io/docs/guides/auth/) to set in the nginx config
     auth_orgs: []
-    # -- (optional) Maximum number of idle keepalive connections to upstream servers for each worker
-    upstream_keepalive: 16
     # -- (optional) Name of basic auth secret.
     # In order to use this option, a secret with htpasswd formatted contents at
     # the key ".htpasswd" must exist. For example:

--- a/values.yaml
+++ b/values.yaml
@@ -1162,6 +1162,8 @@ nginx:
     setHeaders: {}
     # -- (optional) List of [auth tenants](https://cortexmetrics.io/docs/guides/auth/) to set in the nginx config
     auth_orgs: []
+    # -- (optional) Maximum number of idle keepalive connections to upstream servers for each worker
+    upstream_keepalive: 16
     # -- (optional) Name of basic auth secret.
     # In order to use this option, a secret with htpasswd formatted contents at
     # the key ".htpasswd" must exist. For example:


### PR DESCRIPTION
Signed-off-by: Josh Carp <jm.carp@gmail.com>

**What this PR does**:

Add a small nginx optimization: enable keepalive to cortex components. Note that this requires configuring upstreams with explicit `upstream` blocks. I noticed this in a post from nginx at https://www.nginx.com/blog/avoiding-top-10-nginx-configuration-mistakes/#no-keepalives; I tested it out and got a modest drop in nginx cpu use.

**Checklist**
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`