### PR TITLE
Add podManagementPolicy to store gateway statefulset template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## master / unreleased
 
-## 1.4.0 / 2022-03-11
+* [ENHANCEMENT] Allow StoreGateway podManagementPolicy to be changed #332
+
+## 1.4.0 / 2022-03-08
 
 * [ENHANCEMENT] Upgrade to Cortex v1.11.1 #331
 * [ENHANCEMENT] Includes enable flags for each component #319

--- a/README.md
+++ b/README.md
@@ -716,6 +716,7 @@ Kubernetes: `^1.19.0-0`
 | store_gateway.&ZeroWidthSpace;podAnnotations | object | `{"prometheus.io/port":"8080","prometheus.io/scrape":"true"}` | Pod Annotations |
 | store_gateway.&ZeroWidthSpace;podDisruptionBudget.&ZeroWidthSpace;maxUnavailable | int | `1` |  |
 | store_gateway.&ZeroWidthSpace;podLabels | object | `{}` | Pod Labels |
+| store_gateway.&ZeroWidthSpace;podManagementPolicy | string | `"OrderedReady"` | https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#pod-management-policies |
 | store_gateway.&ZeroWidthSpace;readinessProbe.&ZeroWidthSpace;httpGet.&ZeroWidthSpace;path | string | `"/ready"` |  |
 | store_gateway.&ZeroWidthSpace;readinessProbe.&ZeroWidthSpace;httpGet.&ZeroWidthSpace;port | string | `"http-metrics"` |  |
 | store_gateway.&ZeroWidthSpace;replicas | int | `1` |  |

--- a/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/templates/store-gateway/store-gateway-statefulset.yaml
@@ -16,6 +16,7 @@ spec:
       {{- include "cortex.storeGatewaySelectorLabels" . | nindent 6 }}
   updateStrategy:
     {{- toYaml .Values.store_gateway.strategy | nindent 4 }}
+  podManagementPolicy: {{ .Values.store_gateway.podManagementPolicy | quote }}
   serviceName: {{ template "cortex.fullname" . }}-store-gateway-headless
   {{- if .Values.store_gateway.persistentVolume.enabled }}
   volumeClaimTemplates:

--- a/values.yaml
+++ b/values.yaml
@@ -1180,6 +1180,8 @@ nginx:
 store_gateway:
   enabled: true
   replicas: 1
+  # -- https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#pod-management-policies
+  podManagementPolicy: OrderedReady
 
   service:
     annotations: {}


### PR DESCRIPTION
Signed-off-by: Ankit Mehta <ankit.mehta@appian.com>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
3. Please do not edit/bump the Chart.yaml "version" field
-->

**What this PR does**:
Allows one to set PodManagementPolicy on store-gateway Satefulset same as how we can do that for Ingesters in this helm chart.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`