### PR TITLE
Use .Release.Name in frontend.memcached.address to match service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,6 @@
 ## master / unreleased
 
 * [FEATURE] Add Query-Scheduler #268
-
-
 * [ENHANCEMENT] Allow StoreGateway podManagementPolicy to be changed #332
 * [BUGFIX] Correct a typo in enabling distributor HPA #334
 * [BUGFIX] Frontend memcached address did not match the Service #337

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * [ENHANCEMENT] Allow StoreGateway podManagementPolicy to be changed #332
 * [BUGFIX] Correct a typo in enabling distribtuor HPA #334
 * [FEATURE] Add Query-Scheduler #268
+* [BUGFIX] Frontend memcached address did not match the Service #337
 
 ## 1.4.0 / 2022-03-08
 

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -109,7 +109,7 @@ Create configuration for frontend memcached configuration
 */}}
 {{- define "cortex.frontend-memcached" -}}
 {{- if index .Values "memcached-frontend" "enabled" }}
-- "-frontend.memcached.addresses=dns+{{ template "cortex.fullname" . }}-memcached-frontend.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:11211"
+- "-frontend.memcached.addresses=dns+{{ .Release.Name }}-memcached-frontend.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:11211"
 {{- end -}}
 {{- end -}}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
3. Please do not edit/bump the Chart.yaml "version" field
-->

**What this PR does**: Fixes the mapping between the query-frontend and the memcached created for it. The other memcached instances spun up in this chart use `.Release.Name`.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`