### PR TITLE
feat(nginx): ensure dns resolver respects a ttl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * [FEATURE] Add Query-Scheduler #268
 * [ENHANCEMENT] Allow StoreGateway podManagementPolicy to be changed #332
+* [ENHANCEMENT] ensure nginx dns resolver respects a ttl #339
 * [BUGFIX] Correct a typo in enabling distributor HPA #334
 * [BUGFIX] Frontend memcached address did not match the Service #337
 * [BUGFIX] Add service discovery method for query-scheduler addresses #338

--- a/templates/nginx/nginx-config.yaml
+++ b/templates/nginx/nginx-config.yaml
@@ -31,7 +31,7 @@ data:
       access_log   /dev/stderr  main;
       sendfile     on;
       tcp_nopush   on;
-      resolver {{ default (printf "kube-dns.kube-system.svc.%s" .Values.clusterDomain ) .Values.nginx.config.dnsResolver }};
+      resolver {{ default (printf "kube-dns.kube-system.svc.%s" .Values.clusterDomain ) .Values.nginx.config.dnsResolver }} valid={{ default "10s" .Values.nginx.config.dnsTtl }};
 
       {{- with .Values.nginx.config.httpSnippet }}
       {{ tpl . $ | nindent 6 }}
@@ -68,98 +68,103 @@ data:
         }
 
         {{- if .Values.distributor.enabled }}
+        set $distributor_backend "http://{{ template "cortex.fullname" . }}-distributor.{{ $rootDomain }}";
 
         # Distributor Config
         location = /ring {
-          proxy_pass      http://{{ template "cortex.fullname" . }}-distributor.{{ $rootDomain }}$request_uri;
+          proxy_pass      $distributor_backend$request_uri;
         }
 
         location = /all_user_stats {
-          proxy_pass      http://{{ template "cortex.fullname" . }}-distributor.{{ $rootDomain }}$request_uri;
+          proxy_pass      $distributor_backend$request_uri;
         }
 
         location = /api/prom/push {
-          proxy_pass      http://{{ template "cortex.fullname" . }}-distributor.{{ $rootDomain }}$request_uri;
+          proxy_pass      $distributor_backend$request_uri;
         }
 
         ## New Remote write API. Ref: https://cortexmetrics.io/docs/api/#remote-write
         location = /api/v1/push {
-          proxy_pass      http://{{ template "cortex.fullname" . }}-distributor.{{ $rootDomain }}$request_uri;
+          proxy_pass      $distributor_backend$request_uri;
         }
 
         {{- end }}
 
         {{- if .Values.alertmanager.enabled }}
+        set $alertmanager_backend "http://{{ template "cortex.fullname" . }}-alertmanager.{{ $rootDomain }}";
 
         # Alertmanager Config
         location ~ /api/prom/alertmanager/.* {
-          proxy_pass      http://{{ template "cortex.fullname" . }}-alertmanager.{{ $rootDomain }}$request_uri;
+          proxy_pass      $alertmanager_backend$request_uri;
         }
 
         location ~ /api/v1/alerts {
-          proxy_pass      http://{{ template "cortex.fullname" . }}-alertmanager.{{ $rootDomain }}$request_uri;
+          proxy_pass      $alertmanager_backend$request_uri;
         }
 
         location ~ /multitenant_alertmanager/status {
-          proxy_pass      http://{{ template "cortex.fullname" . }}-alertmanager.{{ $rootDomain }}$request_uri;
+          proxy_pass      $alertmanager_backend$request_uri;
         }
 
         location = /api/prom/api/v1/alerts {
-          proxy_pass      http://{{ template "cortex.fullname" . }}-alertmanager.{{ $rootDomain }}/api/v1/alerts;
+          proxy_pass      $alertmanager_backend/api/v1/alerts;
         }
 
         {{- end }}
 
         {{- if .Values.ruler.enabled }}
+        set $ruler_backend "http://{{ template "cortex.fullname" . }}-ruler.{{ $rootDomain }}";
 
         # Ruler Config
         location ~ /api/v1/rules {
-          proxy_pass      http://{{ template "cortex.fullname" . }}-ruler.{{ $rootDomain }}$request_uri;
+          proxy_pass      $ruler_backend$request_uri;
         }
 
         location ~ /ruler/ring {
-          proxy_pass      http://{{ template "cortex.fullname" . }}-ruler.{{ $rootDomain }}$request_uri;
+          proxy_pass      $ruler_backendrequest_uri;
         }
 
         location ~ /api/prom/rules {
-          proxy_pass      http://{{ template "cortex.fullname" . }}-ruler.{{ $rootDomain }}$request_uri;
+          proxy_pass      $ruler_backend$request_uri;
         }
 
         {{- end }}
 
         {{- if .Values.configs.enabled }}
+        set $configs_backend "http://{{ template "cortex.fullname" . }}-configs.{{ $rootDomain }}";
 
         # Config Config
         location ~ /api/prom/configs/.* {
-          proxy_pass      http://{{ template "cortex.fullname" . }}-configs.{{ $rootDomain }}$request_uri;
+          proxy_pass      $configs_backend$request_uri;
         }
 
         {{- end }}
 
         {{- if .Values.query_frontend.enabled }}
+        set $query_frontend_backend "http://{{ template "cortex.fullname" . }}-query-frontend.{{ $rootDomain }}";
 
         # Query Config
         location ~ /api/prom/.* {
-          proxy_pass      http://{{ template "cortex.fullname" . }}-query-frontend.{{ $rootDomain }}$request_uri;
+          proxy_pass      $query_frontend_backend$request_uri;
         }
 
         ## New Query frontend APIs as per https://cortexmetrics.io/docs/api/#querier--query-frontend
         location ~ ^{{.Values.config.api.prometheus_http_prefix}}/api/v1/(read|metadata|labels|series|query_range|query) {
-          proxy_pass      http://{{ template "cortex.fullname" . }}-query-frontend.{{ $rootDomain }}$request_uri;
+          proxy_pass      $query_frontend_backend$request_uri;
         }
 
         location ~ {{.Values.config.api.prometheus_http_prefix}}/api/v1/label/.* {
-          proxy_pass      http://{{ template "cortex.fullname" . }}-query-frontend.{{ $rootDomain }}$request_uri;
+          proxy_pass      $query_frontend_backend$request_uri;
         }
 
         {{- end }}
 
-        {{- if and (.Values.config.auth_enabled) (.Values.nginx.config.auth_orgs) }}
+        {{- if and (and (.Values.config.auth_enabled) (.Values.nginx.config.auth_orgs)) .Values.distributor.enabled }}
         # Auth orgs
         {{- range $org := compact .Values.nginx.config.auth_orgs | uniq }}
         location = /api/v1/push/{{ $org }} {
           proxy_set_header      X-Scope-OrgID {{ $org }};
-          proxy_pass      http://{{ template "cortex.fullname" $ }}-distributor.{{ $rootDomain }}/api/v1/push;
+          proxy_pass      $distributor_backend/api/v1/push;
         }
         {{- end }}
         {{- end }}

--- a/templates/nginx/nginx-config.yaml
+++ b/templates/nginx/nginx-config.yaml
@@ -31,7 +31,7 @@ data:
       access_log   /dev/stderr  main;
       sendfile     on;
       tcp_nopush   on;
-      resolver {{ default (printf "kube-dns.kube-system.svc.%s" .Values.clusterDomain ) .Values.nginx.config.dnsResolver }} valid={{ default "10s" .Values.nginx.config.dnsTtl }};
+      resolver {{ default (printf "kube-dns.kube-system.svc.%s" .Values.clusterDomain ) .Values.nginx.config.dnsResolver }}{{ with .Values.nginx.config.dnsTTL }} valid={{ . }}{{ end }};
 
       {{- with .Values.nginx.config.httpSnippet }}
       {{ tpl . $ | nindent 6 }}

--- a/values.yaml
+++ b/values.yaml
@@ -1151,7 +1151,7 @@ nginx:
   http_listen_port: 80
   config:
     dnsResolver: kube-dns.kube-system.svc.cluster.local
-    dnsTtl: 10s
+    dnsTTL: 10s
     # -- ref: http://nginx.org/en/docs/http/ngx_http_core_module.html#client_max_body_size
     client_max_body_size: 1M
     # -- arbitrary snippet to inject in the http { } section of the nginx config

--- a/values.yaml
+++ b/values.yaml
@@ -1151,6 +1151,7 @@ nginx:
   http_listen_port: 80
   config:
     dnsResolver: kube-dns.kube-system.svc.cluster.local
+    dnsTtl: 10s
     # -- ref: http://nginx.org/en/docs/http/ngx_http_core_module.html#client_max_body_size
     client_max_body_size: 1M
     # -- arbitrary snippet to inject in the http { } section of the nginx config


### PR DESCRIPTION
when services behind the nginx proxy roll or scale up, nginx does not pick
up the new ips as it never rechecks DNS until it is restarted. this can
be mitigated by setting a ttl with the valid parameter on the DNS
resolver AND by ensuring the domain lookups are made through a variable.

see: https://serverfault.com/questions/240476/how-to-force-nginx-to-resolve-dns-of-a-dynamic-hostname-everytime-when-doing-p/593003#593003

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
3. Please do not edit/bump the Chart.yaml "version" field
-->

**What this PR does**:

ensure the resolver has a suitable validity period and move domains
behind an nginx variable, forcing nginx to recheck DNS when proxying
requests.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`