### PR TITLE
Add Overrides-Exporter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## master / unreleased
 
-# [FEATURE] Add Overrides-Exporter #360
+* [FEATURE] Add Overrides-Exporter #360
 
 ## 1.5.1 / 2022-05-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master / unreleased
 
+# [FEATURE] Add Overrides-Exporter #360
+
 ## 1.5.1 / 2022-05-25
 
 * [BUGFIX] Fix mounting cortex config when using configmap #355

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: 1.5.2
+version: 1.5.1
 appVersion: v1.11.1
 description: 'Horizontally scalable, highly available, multi-tenant, long term Prometheus.'
 home: https://cortexmetrics.io/

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: 1.5.1
+version: 1.5.2
 appVersion: v1.11.1
 description: 'Horizontally scalable, highly available, multi-tenant, long term Prometheus.'
 home: https://cortexmetrics.io/

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # cortex
 
-![Version: 1.5.2](https://img.shields.io/badge/Version-1.5.2-informational?style=flat-square) ![AppVersion: v1.11.1](https://img.shields.io/badge/AppVersion-v1.11.1-informational?style=flat-square)
+![Version: 1.5.1](https://img.shields.io/badge/Version-1.5.1-informational?style=flat-square) ![AppVersion: v1.11.1](https://img.shields.io/badge/AppVersion-v1.11.1-informational?style=flat-square)
 
 Horizontally scalable, highly available, multi-tenant, long term Prometheus.
 
@@ -540,7 +540,7 @@ Kubernetes: `^1.19.0-0`
 | overrides_exporter.&ZeroWidthSpace;annotations | object | `{}` |  |
 | overrides_exporter.&ZeroWidthSpace;containerSecurityContext.&ZeroWidthSpace;enabled | bool | `true` |  |
 | overrides_exporter.&ZeroWidthSpace;containerSecurityContext.&ZeroWidthSpace;readOnlyRootFilesystem | bool | `true` |  |
-| overrides_exporter.&ZeroWidthSpace;enabled | bool | `false` |  |
+| overrides_exporter.&ZeroWidthSpace;enabled | bool | `false` | https://cortexmetrics.io/docs/guides/overrides-exporter/ |
 | overrides_exporter.&ZeroWidthSpace;env | list | `[]` |  |
 | overrides_exporter.&ZeroWidthSpace;extraArgs | object | `{}` | Additional Cortex container arguments, e.g. log.level (debug, info, warn, error) |
 | overrides_exporter.&ZeroWidthSpace;extraContainers | list | `[]` |  |
@@ -552,7 +552,6 @@ Kubernetes: `^1.19.0-0`
 | overrides_exporter.&ZeroWidthSpace;livenessProbe.&ZeroWidthSpace;httpGet.&ZeroWidthSpace;path | string | `"/ready"` |  |
 | overrides_exporter.&ZeroWidthSpace;livenessProbe.&ZeroWidthSpace;httpGet.&ZeroWidthSpace;port | string | `"http-metrics"` |  |
 | overrides_exporter.&ZeroWidthSpace;nodeSelector | object | `{}` |  |
-| overrides_exporter.&ZeroWidthSpace;persistentVolume.&ZeroWidthSpace;subPath | string | `nil` |  |
 | overrides_exporter.&ZeroWidthSpace;podAnnotations | object | `{"prometheus.io/port":"http-metrics","prometheus.io/scrape":"true"}` | Pod Annotations |
 | overrides_exporter.&ZeroWidthSpace;podLabels | object | `{}` | Pod Labels |
 | overrides_exporter.&ZeroWidthSpace;readinessProbe.&ZeroWidthSpace;httpGet.&ZeroWidthSpace;path | string | `"/ready"` |  |

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # cortex
 
-![Version: 1.5.1](https://img.shields.io/badge/Version-1.5.1-informational?style=flat-square) ![AppVersion: v1.11.1](https://img.shields.io/badge/AppVersion-v1.11.1-informational?style=flat-square)
+![Version: 1.5.2](https://img.shields.io/badge/Version-1.5.2-informational?style=flat-square) ![AppVersion: v1.11.1](https://img.shields.io/badge/AppVersion-v1.11.1-informational?style=flat-square)
 
 Horizontally scalable, highly available, multi-tenant, long term Prometheus.
 
@@ -532,6 +532,49 @@ Kubernetes: `^1.19.0-0`
 | nginx.&ZeroWidthSpace;terminationGracePeriodSeconds | int | `10` |  |
 | nginx.&ZeroWidthSpace;tolerations | list | `[]` |  |
 | nginx.&ZeroWidthSpace;topologySpreadConstraints | list | `[]` |  |
+| overrides_exporter.&ZeroWidthSpace;affinity.&ZeroWidthSpace;podAntiAffinity.&ZeroWidthSpace;preferredDuringSchedulingIgnoredDuringExecution[0].&ZeroWidthSpace;podAffinityTerm.&ZeroWidthSpace;labelSelector.&ZeroWidthSpace;matchExpressions[0].&ZeroWidthSpace;key | string | `"app.kubernetes.io/component"` |  |
+| overrides_exporter.&ZeroWidthSpace;affinity.&ZeroWidthSpace;podAntiAffinity.&ZeroWidthSpace;preferredDuringSchedulingIgnoredDuringExecution[0].&ZeroWidthSpace;podAffinityTerm.&ZeroWidthSpace;labelSelector.&ZeroWidthSpace;matchExpressions[0].&ZeroWidthSpace;operator | string | `"In"` |  |
+| overrides_exporter.&ZeroWidthSpace;affinity.&ZeroWidthSpace;podAntiAffinity.&ZeroWidthSpace;preferredDuringSchedulingIgnoredDuringExecution[0].&ZeroWidthSpace;podAffinityTerm.&ZeroWidthSpace;labelSelector.&ZeroWidthSpace;matchExpressions[0].&ZeroWidthSpace;values[0] | string | `"query-scheduler"` |  |
+| overrides_exporter.&ZeroWidthSpace;affinity.&ZeroWidthSpace;podAntiAffinity.&ZeroWidthSpace;preferredDuringSchedulingIgnoredDuringExecution[0].&ZeroWidthSpace;podAffinityTerm.&ZeroWidthSpace;topologyKey | string | `"kubernetes.io/hostname"` |  |
+| overrides_exporter.&ZeroWidthSpace;affinity.&ZeroWidthSpace;podAntiAffinity.&ZeroWidthSpace;preferredDuringSchedulingIgnoredDuringExecution[0].&ZeroWidthSpace;weight | int | `100` |  |
+| overrides_exporter.&ZeroWidthSpace;annotations | object | `{}` |  |
+| overrides_exporter.&ZeroWidthSpace;containerSecurityContext.&ZeroWidthSpace;enabled | bool | `true` |  |
+| overrides_exporter.&ZeroWidthSpace;containerSecurityContext.&ZeroWidthSpace;readOnlyRootFilesystem | bool | `true` |  |
+| overrides_exporter.&ZeroWidthSpace;enabled | bool | `false` |  |
+| overrides_exporter.&ZeroWidthSpace;env | list | `[]` |  |
+| overrides_exporter.&ZeroWidthSpace;extraArgs | object | `{}` | Additional Cortex container arguments, e.g. log.level (debug, info, warn, error) |
+| overrides_exporter.&ZeroWidthSpace;extraContainers | list | `[]` |  |
+| overrides_exporter.&ZeroWidthSpace;extraPorts | list | `[]` |  |
+| overrides_exporter.&ZeroWidthSpace;extraVolumeMounts | list | `[]` |  |
+| overrides_exporter.&ZeroWidthSpace;extraVolumes | list | `[]` |  |
+| overrides_exporter.&ZeroWidthSpace;initContainers | list | `[]` |  |
+| overrides_exporter.&ZeroWidthSpace;lifecycle | object | `{}` |  |
+| overrides_exporter.&ZeroWidthSpace;livenessProbe.&ZeroWidthSpace;httpGet.&ZeroWidthSpace;path | string | `"/ready"` |  |
+| overrides_exporter.&ZeroWidthSpace;livenessProbe.&ZeroWidthSpace;httpGet.&ZeroWidthSpace;port | string | `"http-metrics"` |  |
+| overrides_exporter.&ZeroWidthSpace;nodeSelector | object | `{}` |  |
+| overrides_exporter.&ZeroWidthSpace;persistentVolume.&ZeroWidthSpace;subPath | string | `nil` |  |
+| overrides_exporter.&ZeroWidthSpace;podAnnotations | object | `{"prometheus.io/port":"http-metrics","prometheus.io/scrape":"true"}` | Pod Annotations |
+| overrides_exporter.&ZeroWidthSpace;podLabels | object | `{}` | Pod Labels |
+| overrides_exporter.&ZeroWidthSpace;readinessProbe.&ZeroWidthSpace;httpGet.&ZeroWidthSpace;path | string | `"/ready"` |  |
+| overrides_exporter.&ZeroWidthSpace;readinessProbe.&ZeroWidthSpace;httpGet.&ZeroWidthSpace;port | string | `"http-metrics"` |  |
+| overrides_exporter.&ZeroWidthSpace;resources | object | `{}` |  |
+| overrides_exporter.&ZeroWidthSpace;securityContext | object | `{}` |  |
+| overrides_exporter.&ZeroWidthSpace;service.&ZeroWidthSpace;annotations | object | `{}` |  |
+| overrides_exporter.&ZeroWidthSpace;service.&ZeroWidthSpace;labels | object | `{}` |  |
+| overrides_exporter.&ZeroWidthSpace;serviceMonitor.&ZeroWidthSpace;additionalLabels | object | `{}` |  |
+| overrides_exporter.&ZeroWidthSpace;serviceMonitor.&ZeroWidthSpace;enabled | bool | `false` |  |
+| overrides_exporter.&ZeroWidthSpace;serviceMonitor.&ZeroWidthSpace;extraEndpointSpec | object | `{}` | Additional endpoint configuration https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#endpoint |
+| overrides_exporter.&ZeroWidthSpace;serviceMonitor.&ZeroWidthSpace;metricRelabelings | list | `[]` |  |
+| overrides_exporter.&ZeroWidthSpace;serviceMonitor.&ZeroWidthSpace;relabelings | list | `[]` |  |
+| overrides_exporter.&ZeroWidthSpace;startupProbe.&ZeroWidthSpace;failureThreshold | int | `10` |  |
+| overrides_exporter.&ZeroWidthSpace;startupProbe.&ZeroWidthSpace;httpGet.&ZeroWidthSpace;path | string | `"/ready"` |  |
+| overrides_exporter.&ZeroWidthSpace;startupProbe.&ZeroWidthSpace;httpGet.&ZeroWidthSpace;port | string | `"http-metrics"` |  |
+| overrides_exporter.&ZeroWidthSpace;strategy.&ZeroWidthSpace;rollingUpdate.&ZeroWidthSpace;maxSurge | int | `0` |  |
+| overrides_exporter.&ZeroWidthSpace;strategy.&ZeroWidthSpace;rollingUpdate.&ZeroWidthSpace;maxUnavailable | int | `1` |  |
+| overrides_exporter.&ZeroWidthSpace;strategy.&ZeroWidthSpace;type | string | `"RollingUpdate"` |  |
+| overrides_exporter.&ZeroWidthSpace;terminationGracePeriodSeconds | int | `180` |  |
+| overrides_exporter.&ZeroWidthSpace;tolerations | list | `[]` |  |
+| overrides_exporter.&ZeroWidthSpace;topologySpreadConstraints | list | `[]` |  |
 | querier.&ZeroWidthSpace;affinity.&ZeroWidthSpace;podAntiAffinity.&ZeroWidthSpace;preferredDuringSchedulingIgnoredDuringExecution[0].&ZeroWidthSpace;podAffinityTerm.&ZeroWidthSpace;labelSelector.&ZeroWidthSpace;matchExpressions[0].&ZeroWidthSpace;key | string | `"app.kubernetes.io/component"` |  |
 | querier.&ZeroWidthSpace;affinity.&ZeroWidthSpace;podAntiAffinity.&ZeroWidthSpace;preferredDuringSchedulingIgnoredDuringExecution[0].&ZeroWidthSpace;podAffinityTerm.&ZeroWidthSpace;labelSelector.&ZeroWidthSpace;matchExpressions[0].&ZeroWidthSpace;operator | string | `"In"` |  |
 | querier.&ZeroWidthSpace;affinity.&ZeroWidthSpace;podAntiAffinity.&ZeroWidthSpace;preferredDuringSchedulingIgnoredDuringExecution[0].&ZeroWidthSpace;podAffinityTerm.&ZeroWidthSpace;labelSelector.&ZeroWidthSpace;matchExpressions[0].&ZeroWidthSpace;values[0] | string | `"querier"` |  |

--- a/templates/overrides-exporter/_helpers-overrides-exporter.tpl
+++ b/templates/overrides-exporter/_helpers-overrides-exporter.tpl
@@ -1,0 +1,23 @@
+
+{{/*
+overrides-exporter fullname
+*/}}
+{{- define "cortex.overridesExporterFullname" -}}
+{{ include "cortex.fullname" . }}-overrides-exporter
+{{- end }}
+
+{{/*
+overrides-exporter common labels
+*/}}
+{{- define "cortex.overridesExporterLabels" -}}
+{{ include "cortex.labels" . }}
+app.kubernetes.io/component: overrides-exporter
+{{- end }}
+
+{{/*
+overrides-exporter selector labels
+*/}}
+{{- define "cortex.overridesExporterSelectorLabels" -}}
+{{ include "cortex.selectorLabels" . }}
+app.kubernetes.io/component: overrides-exporter
+{{- end }}

--- a/templates/overrides-exporter/overrides-exporter-dep.yaml
+++ b/templates/overrides-exporter/overrides-exporter-dep.yaml
@@ -1,0 +1,113 @@
+{{- if .Values.overrides_exporter.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "cortex.overridesExporterFullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "cortex.overridesExporterLabels" . | nindent 4 }}
+  annotations:
+    {{- toYaml .Values.overrides_exporter.annotations | nindent 4 }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "cortex.overridesExporterSelectorLabels" . | nindent 6 }}
+  strategy:
+    {{- toYaml .Values.overrides_exporter.strategy | nindent 4 }}
+  template:
+    metadata:
+      labels:
+        {{- include "cortex.overridesExporterLabels" . | nindent 8 }}
+        {{- with .Values.overrides_exporter.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      annotations:
+      {{- if .Values.useExternalConfig }}
+        checksum/config: {{ .Values.externalConfigVersion }}
+      {{- else }}
+        checksum/config: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+      {{- end }}
+      {{- with .Values.overrides_exporter.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      serviceAccountName: {{ template "cortex.serviceAccountName" . }}
+      {{- if .Values.overrides_exporter.priorityClassName }}
+      priorityClassName: {{ .Values.overrides_exporter.priorityClassName }}
+      {{- end }}
+      {{- if .Values.overrides_exporter.securityContext.enabled }}
+      securityContext: {{- omit .Values.overrides_exporter.securityContext "enabled" | toYaml | nindent 8 }}
+      {{- end }}
+      initContainers:
+        {{- toYaml .Values.overrides_exporter.initContainers | nindent 8 }}
+      {{- if .Values.image.pullSecrets }}
+      imagePullSecrets:
+      {{- range .Values.image.pullSecrets }}
+        - name: {{ . }}
+      {{- end }}
+      {{- end }}
+      containers:
+        - name: overrides-exporter
+          image: "{{ .Values.image.repository }}:{{ default .Chart.AppVersion .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+            - "-target=overrides-exporter"
+            - "-config.file=/etc/cortex/cortex.yaml"
+          {{- range $key, $value := .Values.overrides_exporter.extraArgs }}
+            - "-{{ $key }}={{ $value }}"
+          {{- end }}
+          volumeMounts:
+            {{- if .Values.overrides_exporter.extraVolumeMounts }}
+            {{- toYaml .Values.overrides_exporter.extraVolumeMounts | nindent 12 }}
+            {{- end }}
+            - name: config
+              mountPath: /etc/cortex
+            - name: runtime-config
+              mountPath: /etc/cortex-runtime-config
+          ports:
+            - name: http-metrics
+              containerPort: {{ .Values.config.server.http_listen_port }}
+              protocol: TCP
+          startupProbe:
+            {{- toYaml .Values.overrides_exporter.startupProbe | nindent 12 }}
+          livenessProbe:
+            {{- toYaml .Values.overrides_exporter.livenessProbe | nindent 12 }}
+          readinessProbe:
+            {{- toYaml .Values.overrides_exporter.readinessProbe | nindent 12 }}
+          resources:
+            {{- toYaml .Values.overrides_exporter.resources | nindent 12 }}
+          {{- if .Values.overrides_exporter.containerSecurityContext.enabled }}
+          securityContext: {{- omit .Values.overrides_exporter.containerSecurityContext "enabled" | toYaml | nindent 12 }}
+          {{- end }}
+          {{- if .Values.overrides_exporter.env }}
+          env:
+            {{- toYaml .Values.overrides_exporter.env | nindent 12 }}
+          {{- end }}
+          {{- with .Values.overrides_exporter.lifecycle }}
+          lifecycle:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+        {{- if .Values.overrides_exporter.extraContainers }}
+        {{- toYaml .Values.overrides_exporter.extraContainers | nindent 8 }}
+        {{- end }}
+      nodeSelector:
+        {{- toYaml .Values.overrides_exporter.nodeSelector | nindent 8 }}
+      {{- if .Values.overrides_exporter.topologySpreadConstraints }}
+      topologySpreadConstraints:
+      {{- toYaml .Values.overrides_exporter.topologySpreadConstraints | nindent 8}}
+      {{- end }}
+      affinity:
+        {{- toYaml .Values.overrides_exporter.affinity | nindent 8 }}
+      tolerations:
+        {{- toYaml .Values.overrides_exporter.tolerations | nindent 8 }}
+      terminationGracePeriodSeconds: {{ .Values.overrides_exporter.terminationGracePeriodSeconds }}
+      volumes:
+        {{- include "cortex.configVolume" . | nindent 8 }}
+        - name: runtime-config
+          configMap:
+            name: {{ template "cortex.fullname" . }}-runtime-config
+        {{- if .Values.overrides_exporter.extraVolumes }}
+        {{- toYaml .Values.overrides_exporter.extraVolumes | nindent 8 }}
+        {{- end }}
+{{- end }}

--- a/templates/overrides-exporter/overrides-exporter-servicemonitor.yaml
+++ b/templates/overrides-exporter/overrides-exporter-servicemonitor.yaml
@@ -1,0 +1,42 @@
+{{- if and .Values.overrides_exporter.enabled .Values.overrides_exporter.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "cortex.overridesExporterFullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "cortex.overridesExporterLabels" . | nindent 4 }}
+    {{- if .Values.overrides_exporter.serviceMonitor.additionalLabels }}
+{{ toYaml .Values.overrides_exporter.serviceMonitor.additionalLabels | indent 4 }}
+    {{- end }}
+  {{- if .Values.overrides_exporter.serviceMonitor.annotations }}
+  annotations:
+{{ toYaml .Values.overrides_exporter.serviceMonitor.annotations | indent 4 }}
+  {{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "cortex.overridesExporterSelectorLabels" . | nindent 6 }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace | quote }}
+  endpoints:
+  - port: http-metrics
+    {{- if .Values.overrides_exporter.serviceMonitor.interval }}
+    interval: {{ .Values.overrides_exporter.serviceMonitor.interval }}
+    {{- end }}
+    {{- if .Values.overrides_exporter.serviceMonitor.scrapeTimeout }}
+    scrapeTimeout: {{ .Values.overrides_exporter.serviceMonitor.scrapeTimeout }}
+    {{- end }}
+    {{- if .Values.overrides_exporter.serviceMonitor.relabelings }}
+    relabelings:
+    {{- toYaml .Values.overrides_exporter.serviceMonitor.relabelings | nindent 4 }}
+    {{- end }}
+    {{- if .Values.overrides_exporter.serviceMonitor.metricRelabelings }}
+    metricRelabelings:
+    {{- toYaml .Values.overrides_exporter.serviceMonitor.metricRelabelings | nindent 4 }}
+    {{- end }}
+    {{- with .Values.overrides_exporter.serviceMonitor.extraEndpointSpec }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+{{- end }}

--- a/templates/overrides-exporter/overrides-exporter-svc.yaml
+++ b/templates/overrides-exporter/overrides-exporter-svc.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.overrides_exporter.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "cortex.overridesExporterFullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "cortex.overridesExporterLabels" . | nindent 4 }}
+    {{- with .Values.overrides_exporter.service.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  annotations:
+    {{- toYaml .Values.overrides_exporter.service.annotations | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: {{ .Values.config.server.http_listen_port }}
+      protocol: TCP
+      name: http-metrics
+      targetPort: http-metrics
+  selector:
+    {{- include "cortex.overridesExporterSelectorLabels" . | nindent 4 }}
+{{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -996,7 +996,7 @@ query_scheduler:
   lifecycle: {}
 
 overrides_exporter:
-  # https://cortexmetrics.io/docs/guides/overrides-exporter/
+  # -- https://cortexmetrics.io/docs/guides/overrides-exporter/
   enabled: false
 
   service:

--- a/values.yaml
+++ b/values.yaml
@@ -1040,8 +1040,6 @@ overrides_exporter:
             topologyKey: 'kubernetes.io/hostname'
 
   annotations: {}
-  persistentVolume:
-    subPath:
 
   startupProbe:
     httpGet:

--- a/values.yaml
+++ b/values.yaml
@@ -995,6 +995,91 @@ query_scheduler:
   env: []
   lifecycle: {}
 
+overrides_exporter:
+  # https://cortexmetrics.io/docs/guides/overrides-exporter/
+  enabled: false
+
+  service:
+    annotations: {}
+    labels: {}
+
+  serviceMonitor:
+    enabled: false
+    additionalLabels: {}
+    relabelings: []
+    metricRelabelings: []
+    # -- Additional endpoint configuration https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#endpoint
+    extraEndpointSpec: {}
+
+  resources: {}
+
+  # -- Additional Cortex container arguments, e.g. log.level (debug, info, warn, error)
+  extraArgs: {}
+
+  # -- Pod Labels
+  podLabels: {}
+
+  # -- Pod Annotations
+  podAnnotations:
+    prometheus.io/scrape: 'true'
+    prometheus.io/port: 'http-metrics'
+
+  nodeSelector: {}
+  topologySpreadConstraints: []
+  affinity:
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 100
+          podAffinityTerm:
+            labelSelector:
+              matchExpressions:
+                - key: app.kubernetes.io/component
+                  operator: In
+                  values:
+                    - query-scheduler
+            topologyKey: 'kubernetes.io/hostname'
+
+  annotations: {}
+  persistentVolume:
+    subPath:
+
+  startupProbe:
+    httpGet:
+      path: /ready
+      port: http-metrics
+    failureThreshold: 10
+  livenessProbe:
+    httpGet:
+      path: /ready
+      port: http-metrics
+  readinessProbe:
+    httpGet:
+      path: /ready
+      port: http-metrics
+
+  securityContext: {}
+  containerSecurityContext:
+    enabled: true
+    readOnlyRootFilesystem: true
+
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+
+  terminationGracePeriodSeconds: 180
+
+  tolerations: []
+
+  initContainers: []
+  extraContainers: []
+  extraVolumes: []
+  extraVolumeMounts: []
+  extraPorts: []
+  env: []
+  lifecycle: {}
+
 table_manager:
   replicas: 1
 


### PR DESCRIPTION
Signed-off-by: Taylor Mutch <taylormutch@gmail.com>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
3. Please do not edit/bump the Chart.yaml "version" field
-->

**What this PR does**:
Adds opt-in support for deploying the Cortex overrides exporter. I followed the pattern from the `query-scheduler`, and set the exporter to only run 1 pod (since its metrics should only be collected once for the cluster).

**Which issue(s) this PR fixes**:
Fixes #359 

**Checklist**
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`