### PR TITLE
Fix query-scheduler address for query-frontend to use correct address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## master / unreleased
 
 * [FEATURE] Add Overrides-Exporter #360
+* [BUGFIX] Fix query-scheduler address for query-frontend to use correct address #364
 
 ## 1.5.1 / 2022-05-25
 

--- a/templates/query-frontend/query-frontend-dep.yaml
+++ b/templates/query-frontend/query-frontend-dep.yaml
@@ -52,7 +52,7 @@ spec:
             - "-config.file=/etc/cortex/cortex.yaml"
             {{- include "cortex.frontend-memcached" . | nindent 12 }}
           {{- if .Values.query_scheduler.enabled }}
-            - "-frontend.scheduler-address=dns+{{ template "cortex.querySchedulerFullname" . }}-headless.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.config.server.grpc_listen_port }}"
+            - "-frontend.scheduler-address={{ template "cortex.querySchedulerFullname" . }}-headless.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.config.server.grpc_listen_port }}"
           {{- end }}
           {{- range $key, $value := .Values.query_frontend.extraArgs }}
             - "-{{ $key }}={{ $value }}"


### PR DESCRIPTION
Signed-off-by: Taylor Mutch <taylormutch@gmail.com>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
3. Please do not edit/bump the Chart.yaml "version" field
-->

**What this PR does**:

Adjusts the `scheduler-address` in the query-frontend to be the same passed to the querier.

**Which issue(s) this PR fixes**:
Fixes https://github.com/cortexproject/cortex-helm-chart/issues/363

**Checklist**
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`