### PR TITLE
move sidecar image back to kiwigrid/k8s-sidecar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## master / unreleased
 
 * [FEATURE] Add Overrides-Exporter #360
+* [CHANGE] move from omegavvweapon/kopf-k8s-sidecar to kiwigrid/k8s-sidecar #365
 
 ## 1.5.1 / 2022-05-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## master / unreleased
 
-* [FEATURE] Add Overrides-Exporter #360
 * [CHANGE] move from omegavvweapon/kopf-k8s-sidecar to kiwigrid/k8s-sidecar #365
+* [FEATURE] Add Overrides-Exporter #360
 
 ## 1.5.1 / 2022-05-25
 

--- a/README.md
+++ b/README.md
@@ -142,9 +142,9 @@ Kubernetes: `^1.19.0-0`
 | alertmanager.&ZeroWidthSpace;sidecar.&ZeroWidthSpace;enabled | bool | `false` | Enable sidecar that collect the configmaps with specified label and stores the included files them into the respective folders |
 | alertmanager.&ZeroWidthSpace;sidecar.&ZeroWidthSpace;folder | string | `"/data"` | Folder where the files should be placed. |
 | alertmanager.&ZeroWidthSpace;sidecar.&ZeroWidthSpace;folderAnnotation | string | `"k8s-sidecar-target-directory"` | The annotation the sidecar will look for in ConfigMaps and/or Secrets to override the destination folder for files. If the value is a relative path, it will be relative to FOLDER |
-| alertmanager.&ZeroWidthSpace;sidecar.&ZeroWidthSpace;image.&ZeroWidthSpace;repository | string | `"omegavveapon/kopf-k8s-sidecar"` |  |
+| alertmanager.&ZeroWidthSpace;sidecar.&ZeroWidthSpace;image.&ZeroWidthSpace;repository | string | `"kiwigrid/k8s-sidecar"` |  |
 | alertmanager.&ZeroWidthSpace;sidecar.&ZeroWidthSpace;image.&ZeroWidthSpace;sha | string | `""` |  |
-| alertmanager.&ZeroWidthSpace;sidecar.&ZeroWidthSpace;image.&ZeroWidthSpace;tag | string | `"1.4.1"` |  |
+| alertmanager.&ZeroWidthSpace;sidecar.&ZeroWidthSpace;image.&ZeroWidthSpace;tag | string | `"1.19.0"` |  |
 | alertmanager.&ZeroWidthSpace;sidecar.&ZeroWidthSpace;imagePullPolicy | string | `"IfNotPresent"` |  |
 | alertmanager.&ZeroWidthSpace;sidecar.&ZeroWidthSpace;label | string | `"cortex_alertmanager"` | Label that should be used for filtering |
 | alertmanager.&ZeroWidthSpace;sidecar.&ZeroWidthSpace;labelValue | string | `""` | The value for the label you want to filter your resources on. Don't set a value to filter by any value |
@@ -756,9 +756,9 @@ Kubernetes: `^1.19.0-0`
 | ruler.&ZeroWidthSpace;sidecar.&ZeroWidthSpace;enabled | bool | `false` | Enable sidecar that collect the configmaps with specified label and stores the included files them into the respective folders |
 | ruler.&ZeroWidthSpace;sidecar.&ZeroWidthSpace;folder | string | `"/data/rules"` | Folder where the files should be placed. |
 | ruler.&ZeroWidthSpace;sidecar.&ZeroWidthSpace;folderAnnotation | string | `"k8s-sidecar-target-directory"` | The annotation the sidecar will look for in ConfigMaps and/or Secrets to override the destination folder for files. If the value is a relative path, it will be relative to FOLDER |
-| ruler.&ZeroWidthSpace;sidecar.&ZeroWidthSpace;image.&ZeroWidthSpace;repository | string | `"omegavveapon/kopf-k8s-sidecar"` |  |
+| ruler.&ZeroWidthSpace;sidecar.&ZeroWidthSpace;image.&ZeroWidthSpace;repository | string | `"kiwigrid/k8s-sidecar"` |  |
 | ruler.&ZeroWidthSpace;sidecar.&ZeroWidthSpace;image.&ZeroWidthSpace;sha | string | `""` |  |
-| ruler.&ZeroWidthSpace;sidecar.&ZeroWidthSpace;image.&ZeroWidthSpace;tag | string | `"1.4.1"` |  |
+| ruler.&ZeroWidthSpace;sidecar.&ZeroWidthSpace;image.&ZeroWidthSpace;tag | string | `"1.19.0"` |  |
 | ruler.&ZeroWidthSpace;sidecar.&ZeroWidthSpace;imagePullPolicy | string | `"IfNotPresent"` |  |
 | ruler.&ZeroWidthSpace;sidecar.&ZeroWidthSpace;label | string | `"cortex_rules"` | label that the configmaps with rules are marked with |
 | ruler.&ZeroWidthSpace;sidecar.&ZeroWidthSpace;labelValue | string | `""` | The value for the label you want to filter your resources on. Don't set a value to filter by any value |

--- a/renovate.json
+++ b/renovate.json
@@ -29,13 +29,13 @@
             "datasourceTemplate": "docker"
         },
         {
-            "description": "Update omegavveapon/kopf-k8s-sidecar image in README.md",
+            "description": "Update kiwigrid/k8s-sidecar image in README.md",
             "fileMatch": ["^README\\.md$"],
             "matchStrings": [
                 "\\|\\s+ruler.&ZeroWidthSpace;sidecar.&ZeroWidthSpace;image.&ZeroWidthSpace;tag\\s+\\|\\s+string\\s+\\|\\s+`\"(?<currentValue>.*?)\"`\\s+\\|\\s+\\|\\s+",
                 "\\|\\s+alertmanager.&ZeroWidthSpace;sidecar.&ZeroWidthSpace;image.&ZeroWidthSpace;tag\\s+\\|\\s+string\\s+\\|\\s+`\"(?<currentValue>.*?)\"`\\s+\\|\\s+\\|\\s+"
             ],
-            "depNameTemplate": "omegavveapon/kopf-k8s-sidecar",
+            "depNameTemplate": "kiwigrid/k8s-sidecar",
             "datasourceTemplate": "docker"
         },
         {

--- a/values.yaml
+++ b/values.yaml
@@ -290,8 +290,8 @@ alertmanager:
     # -- Enable sidecar that collect the configmaps with specified label and stores the included files them into the respective folders
     enabled: false
     image:
-      repository: omegavveapon/kopf-k8s-sidecar
-      tag: 1.4.1
+      repository: kiwigrid/k8s-sidecar
+      tag: 1.19.0
       sha: ""
     imagePullPolicy: IfNotPresent
     resources: {}
@@ -673,8 +673,8 @@ ruler:
     # -- Enable sidecar that collect the configmaps with specified label and stores the included files them into the respective folders
     enabled: false
     image:
-      repository: omegavveapon/kopf-k8s-sidecar
-      tag: 1.4.1
+      repository: kiwigrid/k8s-sidecar  
+      tag: 1.19.0
       sha: ""
     imagePullPolicy: IfNotPresent
     resources: {}

--- a/values.yaml
+++ b/values.yaml
@@ -673,7 +673,7 @@ ruler:
     # -- Enable sidecar that collect the configmaps with specified label and stores the included files them into the respective folders
     enabled: false
     image:
-      repository: kiwigrid/k8s-sidecar  
+      repository: kiwigrid/k8s-sidecar
       tag: 1.19.0
       sha: ""
     imagePullPolicy: IfNotPresent


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
3. Please do not edit/bump the Chart.yaml "version" field
-->

**What this PR does**:

From the [OmegaVVeapon/kopf-k8s-sidecar](https://github.com/OmegaVVeapon/kopf-k8s-sidecar) repository, the author is recommending us to move back to switch back to the kiwigrid k8s-sidecar:

> The issue with the [kiwigrid k8s-sidecar](https://github.com/kiwigrid/k8s-sidecar) hanging is no longer present as of version [1.15.0](https://github.com/kiwigrid/k8s-sidecar/releases/tag/1.15.0).
> The WATCH_CLIENT_TIMEOUT and WATCH_SERVER_TIMEOUT settings that were introduced in this fork to fix the issue, have now been ported there.
> Thus, I advise users of this repo to switch back to the kiwigrid k8s-sidecar at this point.
> Thank you.

**Which issue(s) this PR fixes**:
This PR aims to move back to the [kiwigrid/k8s-sidecar](https://github.com/kiwigrid/k8s-sidecar) image and also instead of using the `quay.io` registry, they have moved to the `docker.io`.

**Checklist**
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
 
**Additional note**

We are baking this change on our deployment in QA environment for a couple days before rolling out to production environment.