### PR TITLE
Add pod topology spread constrant option to Ingester/Alertmanager sta…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## master / unreleased
 
 * [DEPENDENCY] Update quay.io/cortexproject/cortex Docker tag to v1.13.1 #401
+* [ENHANCEMENT] Add pod topology spread constrant option to Ingester/Alertmanager statefulset
 
 # 1.7.0 / 2022-09-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## master / unreleased
 
 * [DEPENDENCY] Update quay.io/cortexproject/cortex Docker tag to v1.13.1 #401
-* [ENHANCEMENT] Add pod topology spread constrant option to Ingester/Alertmanager statefulset
+* [ENHANCEMENT] Add pod topology spread constrant option to Ingester/Alertmanager statefulset #403
 
 # 1.7.0 / 2022-09-23
 

--- a/templates/alertmanager/alertmanager-statefulset.yaml
+++ b/templates/alertmanager/alertmanager-statefulset.yaml
@@ -71,6 +71,10 @@ spec:
       {{- end }}
       nodeSelector:
         {{- toYaml .Values.alertmanager.nodeSelector | nindent 8 }}
+      {{- if .Values.alertmanager.topologySpreadConstraints }}
+      topologySpreadConstraints:
+      {{- toYaml .Values.alertmanager.topologySpreadConstraints | nindent 8}}
+      {{- end }}
       affinity:
         {{- toYaml .Values.alertmanager.affinity | nindent 8 }}
       tolerations:

--- a/templates/ingester/ingester-statefulset.yaml
+++ b/templates/ingester/ingester-statefulset.yaml
@@ -73,6 +73,10 @@ spec:
       {{- end }}
       nodeSelector:
         {{- toYaml .Values.ingester.nodeSelector | nindent 8 }}
+      {{- if .Values.ingester.topologySpreadConstraints }}
+      topologySpreadConstraints:
+      {{- toYaml .Values.ingester.topologySpreadConstraints | nindent 8}}
+      {{- end }}
       affinity:
         {{- toYaml .Values.ingester.affinity | nindent 8 }}
       tolerations:


### PR DESCRIPTION
…tefulset

**What this PR does**:
Provide the ability to configure Pod Topology Spread Constraints to Ingester/Alertmanager statefulset.  This is a fix for 2 statefulsets that were missed in this: https://github.com/cortexproject/cortex-helm-chart/pull/343

**Checklist**
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`