### PR TITLE
add purger components to cortex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * [DEPENDENCY] Update quay.io/cortexproject/cortex Docker tag to v1.13.1 #401
 * [ENHANCEMENT] Add pod topology spread constrant option to Ingester/Alertmanager statefulset #403
 * [ENHANCEMENT] Add HPA to store gateways #406
+* [ENHANCEMENT] add purger components to cortex #407
 
 # 1.7.0 / 2022-09-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 * [DEPENDENCY] Update quay.io/cortexproject/cortex Docker tag to v1.13.1 #401
 * [ENHANCEMENT] Add pod topology spread constrant option to Ingester/Alertmanager statefulset #403
 * [ENHANCEMENT] Add HPA to store gateways #406
-* [ENHANCEMENT] add purger components to cortex #407
+* [FEATURE] add purger components to cortex #407
 
 # 1.7.0 / 2022-09-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,11 @@
 
 ## master / unreleased
 
+* [FEATURE] add purger components to cortex #407
 * [ENHANCEMENT] Add verboseLogging option to nginx config #402
 * [DEPENDENCY] Update quay.io/cortexproject/cortex Docker tag to v1.13.1 #401
 * [ENHANCEMENT] Add pod topology spread constrant option to Ingester/Alertmanager statefulset #403
 * [ENHANCEMENT] Add HPA to store gateways #406
-* [FEATURE] add purger components to cortex #407
 
 # 1.7.0 / 2022-09-23
 

--- a/README.md
+++ b/README.md
@@ -576,6 +576,48 @@ Kubernetes: `^1.19.0-0`
 | overrides_exporter.&ZeroWidthSpace;terminationGracePeriodSeconds | int | `180` |  |
 | overrides_exporter.&ZeroWidthSpace;tolerations | list | `[]` |  |
 | overrides_exporter.&ZeroWidthSpace;topologySpreadConstraints | list | `[]` |  |
+| purger.&ZeroWidthSpace;affinity | object | `{}` |  |
+| purger.&ZeroWidthSpace;annotations | object | `{}` |  |
+| purger.&ZeroWidthSpace;containerSecurityContext.&ZeroWidthSpace;enabled | bool | `true` |  |
+| purger.&ZeroWidthSpace;containerSecurityContext.&ZeroWidthSpace;readOnlyRootFilesystem | bool | `true` |  |
+| purger.&ZeroWidthSpace;enabled | bool | `false` |  |
+| purger.&ZeroWidthSpace;env | list | `[]` | Extra env variables to pass to the cortex container |
+| purger.&ZeroWidthSpace;extraArgs | object | `{}` | Additional Cortex container arguments, e.g. log.level (debug, info, warn, error) |
+| purger.&ZeroWidthSpace;extraContainers | list | `[]` | Additional containers to be added to the cortex pod. |
+| purger.&ZeroWidthSpace;extraPorts | list | `[]` | Additional ports to the cortex services. Useful to expose extra container ports. |
+| purger.&ZeroWidthSpace;extraVolumeMounts | list | `[]` | Extra volume mounts that will be added to the cortex container |
+| purger.&ZeroWidthSpace;extraVolumes | list | `[]` | Additional volumes to the cortex pod. |
+| purger.&ZeroWidthSpace;initContainers | list | `[]` | Init containers to be added to the cortex pod. |
+| purger.&ZeroWidthSpace;lifecycle | object | `{}` |  |
+| purger.&ZeroWidthSpace;livenessProbe.&ZeroWidthSpace;httpGet.&ZeroWidthSpace;path | string | `"/ready"` |  |
+| purger.&ZeroWidthSpace;livenessProbe.&ZeroWidthSpace;httpGet.&ZeroWidthSpace;port | string | `"http-metrics"` |  |
+| purger.&ZeroWidthSpace;livenessProbe.&ZeroWidthSpace;httpGet.&ZeroWidthSpace;scheme | string | `"HTTP"` |  |
+| purger.&ZeroWidthSpace;nodeSelector | object | `{}` |  |
+| purger.&ZeroWidthSpace;podAnnotations.&ZeroWidthSpace;"prometheus.&ZeroWidthSpace;io/port" | string | `"8080"` |  |
+| purger.&ZeroWidthSpace;podAnnotations.&ZeroWidthSpace;"prometheus.&ZeroWidthSpace;io/scrape" | string | `"true"` |  |
+| purger.&ZeroWidthSpace;podLabels | object | `{}` |  |
+| purger.&ZeroWidthSpace;readinessProbe.&ZeroWidthSpace;httpGet.&ZeroWidthSpace;path | string | `"/ready"` |  |
+| purger.&ZeroWidthSpace;readinessProbe.&ZeroWidthSpace;httpGet.&ZeroWidthSpace;port | string | `"http-metrics"` |  |
+| purger.&ZeroWidthSpace;replicas | int | `1` |  |
+| purger.&ZeroWidthSpace;resources | object | `{}` |  |
+| purger.&ZeroWidthSpace;securityContext | object | `{}` |  |
+| purger.&ZeroWidthSpace;service.&ZeroWidthSpace;annotations | object | `{}` |  |
+| purger.&ZeroWidthSpace;service.&ZeroWidthSpace;labels | object | `{}` |  |
+| purger.&ZeroWidthSpace;serviceAccount.&ZeroWidthSpace;name | string | `""` |  |
+| purger.&ZeroWidthSpace;serviceMonitor.&ZeroWidthSpace;additionalLabels | object | `{}` |  |
+| purger.&ZeroWidthSpace;serviceMonitor.&ZeroWidthSpace;enabled | bool | `false` |  |
+| purger.&ZeroWidthSpace;serviceMonitor.&ZeroWidthSpace;extraEndpointSpec | object | `{}` |  |
+| purger.&ZeroWidthSpace;serviceMonitor.&ZeroWidthSpace;metricRelabelings | list | `[]` |  |
+| purger.&ZeroWidthSpace;serviceMonitor.&ZeroWidthSpace;relabelings | list | `[]` |  |
+| purger.&ZeroWidthSpace;startupProbe.&ZeroWidthSpace;failureThreshold | int | `60` |  |
+| purger.&ZeroWidthSpace;startupProbe.&ZeroWidthSpace;httpGet.&ZeroWidthSpace;path | string | `"/ready"` |  |
+| purger.&ZeroWidthSpace;startupProbe.&ZeroWidthSpace;httpGet.&ZeroWidthSpace;port | string | `"http-metrics"` |  |
+| purger.&ZeroWidthSpace;startupProbe.&ZeroWidthSpace;httpGet.&ZeroWidthSpace;scheme | string | `"HTTP"` |  |
+| purger.&ZeroWidthSpace;startupProbe.&ZeroWidthSpace;initialDelaySeconds | int | `120` |  |
+| purger.&ZeroWidthSpace;startupProbe.&ZeroWidthSpace;periodSeconds | int | `30` |  |
+| purger.&ZeroWidthSpace;strategy.&ZeroWidthSpace;type | string | `"RollingUpdate"` |  |
+| purger.&ZeroWidthSpace;terminationGracePeriodSeconds | int | `60` |  |
+| purger.&ZeroWidthSpace;topologySpreadConstraints | list | `[]` |  |
 | querier.&ZeroWidthSpace;affinity.&ZeroWidthSpace;podAntiAffinity.&ZeroWidthSpace;preferredDuringSchedulingIgnoredDuringExecution[0].&ZeroWidthSpace;podAffinityTerm.&ZeroWidthSpace;labelSelector.&ZeroWidthSpace;matchExpressions[0].&ZeroWidthSpace;key | string | `"app.kubernetes.io/component"` |  |
 | querier.&ZeroWidthSpace;affinity.&ZeroWidthSpace;podAntiAffinity.&ZeroWidthSpace;preferredDuringSchedulingIgnoredDuringExecution[0].&ZeroWidthSpace;podAffinityTerm.&ZeroWidthSpace;labelSelector.&ZeroWidthSpace;matchExpressions[0].&ZeroWidthSpace;operator | string | `"In"` |  |
 | querier.&ZeroWidthSpace;affinity.&ZeroWidthSpace;podAntiAffinity.&ZeroWidthSpace;preferredDuringSchedulingIgnoredDuringExecution[0].&ZeroWidthSpace;podAffinityTerm.&ZeroWidthSpace;labelSelector.&ZeroWidthSpace;matchExpressions[0].&ZeroWidthSpace;values[0] | string | `"querier"` |  |

--- a/templates/purger/_helpers-purger.tpl
+++ b/templates/purger/_helpers-purger.tpl
@@ -1,0 +1,23 @@
+
+{{/*
+purger fullname
+*/}}
+{{- define "cortex.purgerFullname" -}}
+{{ include "cortex.fullname" . }}-purger
+{{- end }}
+
+{{/*
+purger common labels
+*/}}
+{{- define "cortex.purgerLabels" -}}
+{{ include "cortex.labels" . }}
+app.kubernetes.io/component: purger
+{{- end }}
+
+{{/*
+purger selector labels
+*/}}
+{{- define "cortex.purgerSelectorLabels" -}}
+{{ include "cortex.selectorLabels" . }}
+app.kubernetes.io/component: purger
+{{- end }}

--- a/templates/purger/purger-dep.yaml
+++ b/templates/purger/purger-dep.yaml
@@ -1,0 +1,109 @@
+{{- if .Values.purger.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "cortex.purgerFullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "cortex.purgerLabels" . | nindent 4 }}
+  annotations:
+    {{- toYaml .Values.purger.annotations | nindent 4 }}
+spec:
+  replicas: {{ .Values.purger.replicas }}
+  selector:
+    matchLabels:
+      {{- include "cortex.purgerSelectorLabels" . | nindent 6 }}
+  strategy:
+    {{- toYaml .Values.purger.strategy | nindent 4 }}
+  template:
+    metadata:
+      labels:
+        {{- include "cortex.purgerLabels" . | nindent 8 }}
+        {{- with .Values.purger.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      annotations:
+        checksum/config: {{ include "cortex.configChecksum" . }}
+      {{- with .Values.query_frontend.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      serviceAccountName: {{ .Values.purger.serviceAccount.name | default (include "cortex.serviceAccountName" . ) }}
+      {{- if .Values.purger.securityContext.enabled }}
+      securityContext: {{- omit .Values.purger.securityContext "enabled" | toYaml | nindent 8 }}
+      {{- end }}
+      initContainers:
+        {{- toYaml .Values.purger.initContainers | nindent 8 }}
+      {{- if .Values.image.pullSecrets }}
+      imagePullSecrets:
+      {{- range .Values.image.pullSecrets }}
+        - name: {{ . }}
+      {{- end }}
+      {{- end }}
+      containers:
+        - name: purger
+          image: "{{ .Values.image.repository }}:{{ default .Chart.AppVersion .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+            - "-target=purger"
+            - "-config.file=/etc/cortex/cortex.yaml"
+          {{- range $key, $value := .Values.purger.extraArgs }}
+            - "-{{ $key }}={{ $value }}"
+          {{- end }}
+          volumeMounts:
+            {{- if .Values.purger.extraVolumeMounts }}
+            {{- toYaml .Values.purger.extraVolumeMounts | nindent 12}}
+            {{- end }}
+            - name: config
+              mountPath: /etc/cortex
+            - name: runtime-config
+              mountPath: /etc/cortex-runtime-config
+          ports:
+            - name: http-metrics
+              containerPort: {{ .Values.config.server.http_listen_port }}
+              protocol: TCP
+            - name: grpc
+              containerPort: {{ .Values.config.server.grpc_listen_port }}
+              protocol: TCP
+          startupProbe:
+            {{- toYaml .Values.purger.startupProbe | nindent 12 }}
+          livenessProbe:
+            {{- toYaml .Values.purger.livenessProbe | nindent 12 }}
+          readinessProbe:
+            {{- toYaml .Values.purger.readinessProbe | nindent 12 }}
+          resources:
+            {{- toYaml .Values.purger.resources | nindent 12 }}
+          {{- if .Values.purger.containerSecurityContext.enabled }}
+          securityContext: {{- omit .Values.purger.containerSecurityContext "enabled" | toYaml | nindent 12 }}
+          {{- end }}
+          {{- if .Values.purger.env }}
+          env:
+            {{- toYaml .Values.purger.env | nindent 12 }}
+          {{- end }}
+          {{- with .Values.purger.lifecycle }}
+          lifecycle:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+        {{- if .Values.purger.extraContainers }}
+        {{- toYaml .Values.purger.extraContainers | nindent 8}}
+        {{- end }}
+      nodeSelector:
+        {{- toYaml .Values.purger.nodeSelector | nindent 8 }}
+      {{- if .Values.purger.topologySpreadConstraints }}
+      topologySpreadConstraints:
+      {{- toYaml .Values.purger.topologySpreadConstraints | nindent 8}}
+      {{- end }}
+      affinity:
+        {{- toYaml .Values.purger.affinity | nindent 8 }}
+      tolerations:
+        {{- toYaml .Values.purger.tolerations | nindent 8 }}
+      terminationGracePeriodSeconds: {{ .Values.purger.terminationGracePeriodSeconds }}
+      volumes:
+        {{- include "cortex.configVolume" . | nindent 8 }}
+        - name: runtime-config
+          configMap:
+            name: {{ template "cortex.fullname" . }}-runtime-config
+        {{- if .Values.purger.extraVolumes }}
+        {{- toYaml .Values.purger.extraVolumes | nindent 8}}
+        {{- end }}
+{{- end -}}

--- a/templates/purger/purger-servicemonitor.yaml
+++ b/templates/purger/purger-servicemonitor.yaml
@@ -1,0 +1,42 @@
+{{- if .Values.purger.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "cortex.purgerFullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "cortex.purgerLabels" . | nindent 4 }}
+    {{- if .Values.purger.serviceMonitor.additionalLabels }}
+{{ toYaml .Values.purger.serviceMonitor.additionalLabels | indent 4 }}
+    {{- end }}
+  {{- if .Values.purger.serviceMonitor.annotations }}
+  annotations:
+{{ toYaml .Values.purger.serviceMonitor.annotations | indent 4 }}
+  {{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "cortex.purgerSelectorLabels" . | nindent 6 }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace | quote }}
+  endpoints:
+  - port: http-metrics
+    {{- if .Values.purger.serviceMonitor.interval }}
+    interval: {{ .Values.purger.serviceMonitor.interval }}
+    {{- end }}
+    {{- if .Values.purger.serviceMonitor.scrapeTimeout }}
+    scrapeTimeout: {{ .Values.purger.serviceMonitor.scrapeTimeout }}
+    {{- end }}
+    {{- if .Values.purger.serviceMonitor.relabelings }}
+    relabelings:
+    {{- toYaml .Values.purger.serviceMonitor.relabelings | nindent 4 }}
+    {{- end }}
+    {{- if .Values.purger.serviceMonitor.metricRelabelings }}
+    metricRelabelings:
+    {{- toYaml .Values.purger.serviceMonitor.metricRelabelings | nindent 4 }}
+    {{- end }}
+    {{- with .Values.purger.serviceMonitor.extraEndpointSpec }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+{{- end }}

--- a/templates/purger/purger-svc-headless.yaml
+++ b/templates/purger/purger-svc-headless.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.purger.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "cortex.purgerFullname" . }}-headless
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "cortex.purgerLabels" . | nindent 4 }}
+    {{- with .Values.purger.service.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  annotations:
+    {{- toYaml .Values.purger.service.annotations | nindent 4 }}
+spec:
+  type: ClusterIP
+  clusterIP: None
+  publishNotReadyAddresses: true
+  ports:
+    - port: {{ .Values.config.server.grpc_listen_port }}
+      protocol: TCP
+      name: grpc
+      targetPort: grpc
+  selector:
+    {{- include "cortex.purgerSelectorLabels" . | nindent 4 }}
+{{- end }}

--- a/templates/purger/purger-svc.yaml
+++ b/templates/purger/purger-svc.yaml
@@ -1,0 +1,25 @@
+{{- if eq .Values.config.storage.engine "blocks" -}}
+{{- if .Values.purger.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "cortex.purgerFullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "cortex.purgerLabels" . | nindent 4 }}
+    {{- with .Values.purger.service.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  annotations:
+    {{- toYaml .Values.purger.service.annotations | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: {{ .Values.config.server.http_listen_port }}
+      protocol: TCP
+      name: http-metrics
+      targetPort: http-metrics
+  selector:
+    {{- include "cortex.purgerSelectorLabels" . | nindent 4 }}
+{{- end -}}
+{{- end -}}

--- a/templates/querier/querier-dep.yaml
+++ b/templates/querier/querier-dep.yaml
@@ -58,6 +58,9 @@ spec:
           {{- if and .Values.query_frontend.enabled (not .Values.query_scheduler.enabled) }}
             - "-querier.frontend-address={{ template "cortex.queryFrontendFullname" . }}-headless.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.config.server.grpc_listen_port }}"
           {{- end }}
+          {{- if .Values.purger.enabled }}
+            - "-purger.enable"
+          {{- end }}
           {{- include "cortex.memcached" . | nindent 12}}
           {{- range $key, $value := .Values.querier.extraArgs }}
             - "-{{ $key }}={{ $value }}"

--- a/templates/query-frontend/query-frontend-dep.yaml
+++ b/templates/query-frontend/query-frontend-dep.yaml
@@ -54,6 +54,9 @@ spec:
           {{- if .Values.query_scheduler.enabled }}
             - "-frontend.scheduler-address={{ template "cortex.querySchedulerFullname" . }}-headless.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.config.server.grpc_listen_port }}"
           {{- end }}
+          {{- if .Values.purger.enabled }}
+            - "-purger.enable"
+          {{- end }}
           {{- range $key, $value := .Values.query_frontend.extraArgs }}
             - "-{{ $key }}={{ $value }}"
           {{- end }}

--- a/templates/ruler/ruler-dep.yaml
+++ b/templates/ruler/ruler-dep.yaml
@@ -112,6 +112,9 @@ spec:
             - "-ruler.alertmanager-url=http://{{ template "cortex.alertmanagerFullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.config.server.http_listen_port }}/api/prom/alertmanager/"
               {{- end }}
             {{- end }}
+          {{- if .Values.purger.enabled }}
+            - "-purger.enable"
+          {{- end }}
             {{- include "cortex.memcached" . | nindent 12}}
           {{- range $key, $value := .Values.ruler.extraArgs }}
             - "-{{ $key }}={{ $value }}"

--- a/templates/table-manager/table-manager-dep.yaml
+++ b/templates/table-manager/table-manager-dep.yaml
@@ -50,6 +50,9 @@ spec:
           args:
             - "-target=table-manager"
             - "-config.file=/etc/cortex/cortex.yaml"
+          {{- if .Values.purger.enabled }}
+            - "-purger.enable"
+          {{- end }}
           {{- range $key, $value := .Values.table_manager.extraArgs }}
             - "-{{ $key }}={{ $value }}"
           {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -1078,6 +1078,89 @@ overrides_exporter:
   env: []
   lifecycle: {}
 
+purger:
+  enabled: false
+  replicas: 1
+
+  service:
+    annotations: {}
+    labels: {}
+
+  serviceAccount:
+    name: ""
+
+  serviceMonitor:
+    enabled: false
+    additionalLabels: {}
+    relabelings: []
+    metricRelabelings: []
+    extraEndpointSpec: {}
+
+  resources: {}
+
+  strategy:
+    type: RollingUpdate
+
+  podLabels: {}
+
+  podAnnotations:
+    prometheus.io/scrape: 'true'
+    prometheus.io/port: '8080'
+
+  nodeSelector: {}
+  topologySpreadConstraints: []
+  affinity: {}
+  annotations: {}
+  terminationGracePeriodSeconds: 60
+
+  lifecycle: {}
+
+  securityContext: {}
+
+  containerSecurityContext:
+    enabled: true
+    readOnlyRootFilesystem: true
+
+  # -- Additional Cortex container arguments, e.g. log.level (debug, info, warn, error)
+  extraArgs: {}
+
+  # -- Init containers to be added to the cortex pod.
+  initContainers: []
+
+  # -- Additional containers to be added to the cortex pod.
+  extraContainers: []
+
+  # -- Additional volumes to the cortex pod.
+  extraVolumes: []
+
+  # -- Extra volume mounts that will be added to the cortex container
+  extraVolumeMounts: []
+
+  # -- Additional ports to the cortex services. Useful to expose extra container ports.
+  extraPorts: []
+
+  # -- Extra env variables to pass to the cortex container
+  env: []
+
+  startupProbe:
+    failureThreshold: 60
+    initialDelaySeconds: 120
+    periodSeconds: 30
+    httpGet:
+      path: /ready
+      port: http-metrics
+      scheme: HTTP
+  livenessProbe:
+    httpGet:
+      path: /ready
+      port: http-metrics
+      scheme: HTTP
+  readinessProbe:
+    httpGet:
+      path: /ready
+      port: http-metrics
+
+
 table_manager:
   replicas: 1
 


### PR DESCRIPTION
Signed-off-by: AlexandreRoux <alexandreroux42@protonmail.com>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
3. Please do not edit/bump the Chart.yaml "version" field
-->

**What this PR does**:
This PR add the purger service to cortex-helm 
https://cortexmetrics.io/docs/configuration/configuration-file/#purger_config
https://cortexmetrics.io/docs/api/#purger

The purger service is by default `disabled`.
The following services will have the extraArgs container edited with `-purger` :
+ querier
+ query-frontend
+ ruler
+ table-manager

**Which issue(s) this PR fixes**:
Fixes #145

**How to test**:
```
curl -v -XPOST --header "X-Scope-OrgID: fake" ${PURGER_URI}:${PURGER_FW_PORT}/purger/delete_tenant
curl -v -XGET --header "X-Scope-OrgID: fake" ${PURGER_URI}:${PURGER_FW_PORT}/purger/delete_tenant_status

# purger logs
level=info ts=2022-10-20T15:35:42.437155739Z caller=tenant_deletion_api.go:63 msg="tenant deletion mark in blocks storage created" user=fake

# compactor logs
level=info ts=2022-10-20T15:41:38.695346333Z caller=blocks_cleaner.go:144 component=cleaner msg="started blocks cleanup and maintenance"
level=info ts=2022-10-20T15:41:40.278579863Z caller=blocks_cleaner.go:197 component=cleaner org_id=fake msg="deleting blocks for tenant marked for deletion"
level=info ts=2022-10-20T15:41:42.781803963Z caller=blocks_cleaner.go:227 component=cleaner org_id=fake msg="deleted block" block=01G5R2V4HXHVZTBGQB9SPN7S86
level=info ts=2022-10-20T15:41:44.38291108Z caller=blocks_cleaner.go:227 component=cleaner org_id=fake msg="deleted block" block=01G5TNS0KB224V67447Z17KSE5
level=info ts=2022-10-20T15:41:46.022793531Z caller=blocks_cleaner.go:227 component=cleaner org_id=fake msg="deleted block" block=01G5X8J1QA7RFZ60A2KD0Q8Z4C
level=info ts=2022-10-20T15:42:08.123555156Z caller=blocks_cleaner.go:268 component=cleaner org_id=fake msg="updating finished time in tenant deletion mark"
...
...
level=info ts=2022-10-20T15:42:08.348427001Z caller=blocks_cleaner.go:148 component=cleaner msg="successfully completed blocks cleanup and maintenance"
```
**Checklist**
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`