### PR TITLE
Start using autoscaling/v2 for HorizontalPodAutoscaler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## master / unreleased
 
+* [ENHANCEMENT] Start using autoscaling/v2 for HorizontalPodAutoscaler in v1.23+ #414
 * [FEATURE] add purger components to cortex #407
 * [ENHANCEMENT] Add verboseLogging option to nginx config #402
 * [DEPENDENCY] Update quay.io/cortexproject/cortex Docker tag to v1.13.1 #401

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -153,3 +153,14 @@ Get volume of config secret of configMap
     secretName: {{ template "cortex.fullname" . }}
   {{- end }}
 {{- end -}}
+
+{{/*
+Get cortex hpa version by k8s version
+*/}}
+{{- define "cortex.hpaVersion" -}}
+{{- if or (.Capabilities.APIVersions.Has "autoscaling/v2/HorizontalPodAutoscaler") (semverCompare ">=1.23" .Capabilities.KubeVersion.Version) -}}
+autoscaling/v2
+{{- else -}}
+autoscaling/v2beta2
+{{- end -}}
+{{- end -}}

--- a/templates/distributor/distributor-hpa.yaml
+++ b/templates/distributor/distributor-hpa.yaml
@@ -1,6 +1,6 @@
 {{- if and .Values.distributor.enabled .Values.distributor.autoscaling.enabled }}
 {{- with .Values.distributor.autoscaling -}}
-apiVersion: autoscaling/v2beta2
+apiVersion: {{ include "cortex.hpaVersion" $ }}
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "cortex.distributorFullname" $ }}

--- a/templates/ingester/ingester-hpa.yaml
+++ b/templates/ingester/ingester-hpa.yaml
@@ -1,6 +1,6 @@
 {{- if and .Values.ingester.enabled .Values.ingester.autoscaling.enabled -}}
 {{- with .Values.ingester.autoscaling -}}
-apiVersion: autoscaling/v2beta2
+apiVersion: {{ include "cortex.hpaVersion" $ }}
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "cortex.ingesterFullname" $ }}

--- a/templates/nginx/nginx-hpa.yaml
+++ b/templates/nginx/nginx-hpa.yaml
@@ -1,6 +1,6 @@
 {{- if and .Values.nginx.enabled .Values.nginx.autoscaling.enabled }}
 {{- with .Values.nginx.autoscaling -}}
-apiVersion: autoscaling/v2beta2
+apiVersion: {{ include "cortex.hpaVersion" $ }}
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "cortex.nginxFullname" $ }}

--- a/templates/querier/querier-hpa.yaml
+++ b/templates/querier/querier-hpa.yaml
@@ -1,6 +1,6 @@
 {{- if and .Values.querier.enabled .Values.querier.autoscaling.enabled -}}
 {{- with .Values.querier.autoscaling -}}
-apiVersion: autoscaling/v2beta2
+apiVersion: {{ include "cortex.hpaVersion" $ }}
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "cortex.querierFullname" $ }}

--- a/templates/store-gateway/store-gateway-hpa.yaml
+++ b/templates/store-gateway/store-gateway-hpa.yaml
@@ -1,6 +1,6 @@
 {{- if and .Values.store_gateway.enabled .Values.store_gateway.autoscaling.enabled -}}
 {{- with .Values.store_gateway.autoscaling -}}
-apiVersion: autoscaling/v2beta2
+apiVersion: {{ include "cortex.hpaVersion" $ }}
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "cortex.storeGatewayFullname" $ }}


### PR DESCRIPTION
What this PR does / why we need it:

Problem: chart-testing is failing for:
"autoscaling/v2beta2 HorizontalPodAutoscaler is deprecated in v1.23+, unavailable in v1.26+; use autoscaling/v2"

https://github.com/cortexproject/cortex-helm-chart/actions/runs/3606103570/jobs/6077123598

Solution: update charts to start using autoscaler/v2

Signed-off-by: guykomari <guykomari@gmail.com>