### PR TITLE
add autoscaler for the ruler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master / unreleased
 
+* [FEATURE] add autoscaler for the ruler #430
+
 # 2.0.1 / 2023-01-06
 
 * [DEPENDENCY] Update quay.io/cortexproject/cortex Docker tag to v1.14.1 #422

--- a/README.md
+++ b/README.md
@@ -701,6 +701,12 @@ Kubernetes: `^1.19.0-0`
 | query_scheduler.&ZeroWidthSpace;topologySpreadConstraints | list | `[]` |  |
 | ruler.&ZeroWidthSpace;affinity | object | `{}` |  |
 | ruler.&ZeroWidthSpace;annotations | object | `{}` |  |
+| ruler.&ZeroWidthSpace;autoscaling.&ZeroWidthSpace;behavior | object | `{}` | Ref: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#support-for-configurable-scaling-behavior |
+| ruler.&ZeroWidthSpace;autoscaling.&ZeroWidthSpace;enabled | bool | `false` | Creates a HorizontalPodAutoscaler for the ruler. |
+| ruler.&ZeroWidthSpace;autoscaling.&ZeroWidthSpace;maxReplicas | int | `30` |  |
+| ruler.&ZeroWidthSpace;autoscaling.&ZeroWidthSpace;minReplicas | int | `2` |  |
+| ruler.&ZeroWidthSpace;autoscaling.&ZeroWidthSpace;targetCPUUtilizationPercentage | int | `80` |  |
+| ruler.&ZeroWidthSpace;autoscaling.&ZeroWidthSpace;targetMemoryUtilizationPercentage | int | `80` |  |
 | ruler.&ZeroWidthSpace;containerSecurityContext.&ZeroWidthSpace;enabled | bool | `true` |  |
 | ruler.&ZeroWidthSpace;containerSecurityContext.&ZeroWidthSpace;readOnlyRootFilesystem | bool | `true` |  |
 | ruler.&ZeroWidthSpace;directories | object | `{}` | allow configuring rules via configmap. ref: https://cortexproject.github.io/cortex-helm-chart/guides/configure_rules_via_configmap.html |

--- a/README.md
+++ b/README.md
@@ -764,6 +764,7 @@ Kubernetes: `^1.19.0-0`
 | ruler.&ZeroWidthSpace;terminationGracePeriodSeconds | int | `180` |  |
 | ruler.&ZeroWidthSpace;tolerations | list | `[]` |  |
 | ruler.&ZeroWidthSpace;topologySpreadConstraints | list | `[]` |  |
+| ruler.&ZeroWidthSpace;validation.&ZeroWidthSpace;enabled | bool | `true` | Checks that the ruler is compatible with horizontal scaling, as documented in https://cortexmetrics.io/docs/guides/ruler-sharding/. You may need to disable this if your config is compatible, but not understood by the validator. |
 | runtimeconfigmap.&ZeroWidthSpace;annotations | object | `{}` |  |
 | runtimeconfigmap.&ZeroWidthSpace;create | bool | `true` | If true, a configmap for the `runtime_config` will be created. If false, the configmap _must_ exist already on the cluster or pods will fail to create. |
 | runtimeconfigmap.&ZeroWidthSpace;runtime_config | object | `{}` | https://cortexmetrics.io/docs/configuration/arguments/#runtime-configuration-file |

--- a/templates/ruler/_helpers-ruler.tpl
+++ b/templates/ruler/_helpers-ruler.tpl
@@ -28,3 +28,24 @@ format rules dir
 {{- define "cortex.rulerRulesDirName" -}}
 rules-{{ . | replace "_" "-" | trimSuffix "-" }}
 {{- end }}
+
+{{/*
+ruler config validation
+Ref: https://cortexmetrics.io/docs/guides/ruler-sharding/
+*/}}
+{{- define "cortex.rulerValidation" -}}
+{{- with .Values.ruler -}}
+  {{- if .validation.enabled -}}
+    {{- if or (gt (int .replicas) 1) .autoscaling.enabled -}}
+      {{- with $.Values.config.ruler -}}
+        {{- if not .enable_sharding -}}
+          {{- fail "must enable_sharding to scale the ruler" -}}
+        {{- end }}
+        {{- if not ((.ring | default dict).kvstore | default dict).store -}}
+          {{- fail "must configure kvstore to scale the ruler" -}}
+        {{- end }}
+      {{- end }}
+    {{- end }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/templates/ruler/ruler-dep.yaml
+++ b/templates/ruler/ruler-dep.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.ruler.enabled -}}
+{{- include "cortex.rulerValidation" $ -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -10,7 +11,9 @@ metadata:
   annotations:
     {{- toYaml .Values.ruler.annotations | nindent 4 }}
 spec:
+  {{- if not .Values.ruler.autoscaling.enabled }}
   replicas: {{ .Values.ruler.replicas }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "cortex.rulerSelectorLabels" . | nindent 6 }}

--- a/templates/ruler/ruler-hpa.yaml
+++ b/templates/ruler/ruler-hpa.yaml
@@ -1,0 +1,39 @@
+{{- if and .Values.ruler.enabled .Values.ruler.autoscaling.enabled }}
+{{- with .Values.ruler.autoscaling -}}
+apiVersion: {{ include "cortex.hpaVersion" $ }}
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "cortex.rulerFullname" $ }}
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    {{- include "cortex.rulerLabels" $ | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "cortex.rulerFullname" $ }}
+  minReplicas: {{ .minReplicas }}
+  maxReplicas: {{ .maxReplicas }}
+  metrics:
+  {{- with .targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ . }}
+  {{- end }}
+  {{- with .targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ . }}
+  {{- end }}
+  {{- with .behavior }}
+  behavior:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -611,6 +611,16 @@ ruler:
   affinity: {}
   annotations: {}
 
+  autoscaling:
+    # -- Creates a HorizontalPodAutoscaler for the ruler.
+    enabled: false
+    minReplicas: 2
+    maxReplicas: 30
+    targetCPUUtilizationPercentage: 80
+    targetMemoryUtilizationPercentage: 80
+    # -- Ref: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#support-for-configurable-scaling-behavior
+    behavior: {}
+
   startupProbe:
     httpGet:
       path: /ready

--- a/values.yaml
+++ b/values.yaml
@@ -621,6 +621,12 @@ ruler:
     # -- Ref: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#support-for-configurable-scaling-behavior
     behavior: {}
 
+  validation:
+    # -- Checks that the ruler is compatible with horizontal scaling,
+    # as documented in https://cortexmetrics.io/docs/guides/ruler-sharding/.
+    # You may need to disable this if your config is compatible, but not understood by the validator.
+    enabled: true
+
   startupProbe:
     httpGet:
       path: /ready


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
3. Please do not edit/bump the Chart.yaml "version" field
-->

**What this PR does**:
Defines an optional `HorizontalPodAutoscaler` for the ruler.

Requires a config like:
```yaml
config:
  ruler:
    enable_sharding: true
    ring:
      kvstore:
        store: memberlist
ruler:
  autoscaling:
    enabled: true
```
as documented in https://cortexmetrics.io/docs/guides/ruler-sharding/.

~Not sure if we should make any of these default or a condition on the HPA. Or maybe~ added a `fail` block to check for these conditions.

In my experience, both memory and CPU scale pretty linearly with ruler load, so I've included both as target metrics for the ruler HPA.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`