### PR TITLE
change alertmanager-svc-headless from http to grpc port

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * [FEATURE] add autoscaler for the ruler #430
 * [ENHANCEMENT] Add annotations and labels to memberlist service #433
+* [CHANGE] change alertmanager-svc-headless from http to grpc port #420
 
 # 2.0.1 / 2023-01-06
 

--- a/templates/alertmanager/alertmanager-svc-headless.yaml
+++ b/templates/alertmanager/alertmanager-svc-headless.yaml
@@ -17,10 +17,10 @@ spec:
   clusterIP: None
   publishNotReadyAddresses: true
   ports:
-    - port: {{ .Values.config.server.http_listen_port }}
+    - port: {{ .Values.config.server.grpc_listen_port }}
       protocol: TCP
-      name: http-metrics
-      targetPort: http-metrics
+      name: grpc
+      targetPort: grpc
   selector:
     {{- include "cortex.alertmanagerSelectorLabels" . | nindent 4 }}
 {{- end -}}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
3. Please do not edit/bump the Chart.yaml "version" field
-->

**What this PR does**:
This PR correct the alertmanager-headless service with exposing grpc port instead of http.

```
cortex-alertmanager-headless     ClusterIP   None             <none>        9095/TCP    1d
cortex-distributor-headless      ClusterIP   None             <none>        9095/TCP    1d
cortex-ingester-headless         ClusterIP   None             <none>        9095/TCP    1d
cortex-query-frontend-headless   ClusterIP   None             <none>        9095/TCP    1d
cortex-store-gateway-headless    ClusterIP   None             <none>        9095/TCP    1d
```

**Which issue(s) this PR fixes**:
This PR does not fix an issue BUT is related to conversation in #420

**Checklist**
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`