### PR TITLE
Add podTargeLabels to Prometheus ServiceMonitor CRDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * [FEATURE] add autoscaler for the ruler #430
 * [ENHANCEMENT] Add annotations and labels to memberlist service #433
+* [ENHANCEMENT] Add podTargeLabels to all Prometheus servicemonitor CRDs #437
 
 # 2.0.1 / 2023-01-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * [FEATURE] add autoscaler for the ruler #430
 * [ENHANCEMENT] Add annotations and labels to memberlist service #433
-* [ENHANCEMENT] Add podTargeLabels to all Prometheus servicemonitor CRDs #437
+* [ENHANCEMENT] Add podTargeLabels to all Prometheus servicemonitor CRDs #439
 
 # 2.0.1 / 2023-01-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * [FEATURE] add autoscaler for the ruler #430
 * [ENHANCEMENT] Add annotations and labels to memberlist service #433
-* [ENHANCEMENT] Add podTargeLabels to all Prometheus servicemonitor CRDs #439
+* [ENHANCEMENT] Add podTargetLabels to all Prometheus servicemonitor CRs #439
 
 # 2.0.1 / 2023-01-06
 

--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ Kubernetes: `^1.19.0-0`
 | alertmanager.&ZeroWidthSpace;serviceMonitor.&ZeroWidthSpace;enabled | bool | `false` |  |
 | alertmanager.&ZeroWidthSpace;serviceMonitor.&ZeroWidthSpace;extraEndpointSpec | object | `{}` | Additional endpoint configuration https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#endpoint |
 | alertmanager.&ZeroWidthSpace;serviceMonitor.&ZeroWidthSpace;metricRelabelings | list | `[]` |  |
+| alertmanager.&ZeroWidthSpace;serviceMonitor.&ZeroWidthSpace;podTargetLabels | list | `[]` |  |
 | alertmanager.&ZeroWidthSpace;serviceMonitor.&ZeroWidthSpace;relabelings | list | `[]` |  |
 | alertmanager.&ZeroWidthSpace;sidecar.&ZeroWidthSpace;containerSecurityContext.&ZeroWidthSpace;enabled | bool | `true` |  |
 | alertmanager.&ZeroWidthSpace;sidecar.&ZeroWidthSpace;containerSecurityContext.&ZeroWidthSpace;readOnlyRootFilesystem | bool | `true` |  |
@@ -203,6 +204,7 @@ Kubernetes: `^1.19.0-0`
 | compactor.&ZeroWidthSpace;serviceMonitor.&ZeroWidthSpace;enabled | bool | `false` |  |
 | compactor.&ZeroWidthSpace;serviceMonitor.&ZeroWidthSpace;extraEndpointSpec | object | `{}` | Additional endpoint configuration https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#endpoint |
 | compactor.&ZeroWidthSpace;serviceMonitor.&ZeroWidthSpace;metricRelabelings | list | `[]` |  |
+| compactor.&ZeroWidthSpace;serviceMonitor.&ZeroWidthSpace;podTargetLabels | list | `[]` |  |
 | compactor.&ZeroWidthSpace;serviceMonitor.&ZeroWidthSpace;relabelings | list | `[]` |  |
 | compactor.&ZeroWidthSpace;startupProbe.&ZeroWidthSpace;failureThreshold | int | `60` |  |
 | compactor.&ZeroWidthSpace;startupProbe.&ZeroWidthSpace;httpGet.&ZeroWidthSpace;path | string | `"/ready"` |  |
@@ -298,6 +300,7 @@ Kubernetes: `^1.19.0-0`
 | distributor.&ZeroWidthSpace;serviceMonitor.&ZeroWidthSpace;enabled | bool | `false` |  |
 | distributor.&ZeroWidthSpace;serviceMonitor.&ZeroWidthSpace;extraEndpointSpec | object | `{}` | Additional endpoint configuration https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#endpoint |
 | distributor.&ZeroWidthSpace;serviceMonitor.&ZeroWidthSpace;metricRelabelings | list | `[]` |  |
+| distributor.&ZeroWidthSpace;serviceMonitor.&ZeroWidthSpace;podTargetLabels | list | `[]` |  |
 | distributor.&ZeroWidthSpace;serviceMonitor.&ZeroWidthSpace;relabelings | list | `[]` |  |
 | distributor.&ZeroWidthSpace;startupProbe.&ZeroWidthSpace;failureThreshold | int | `10` |  |
 | distributor.&ZeroWidthSpace;startupProbe.&ZeroWidthSpace;httpGet.&ZeroWidthSpace;path | string | `"/ready"` |  |
@@ -361,6 +364,7 @@ Kubernetes: `^1.19.0-0`
 | ingester.&ZeroWidthSpace;serviceMonitor.&ZeroWidthSpace;enabled | bool | `false` |  |
 | ingester.&ZeroWidthSpace;serviceMonitor.&ZeroWidthSpace;extraEndpointSpec | object | `{}` | Additional endpoint configuration https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#endpoint |
 | ingester.&ZeroWidthSpace;serviceMonitor.&ZeroWidthSpace;metricRelabelings | list | `[]` |  |
+| ingester.&ZeroWidthSpace;serviceMonitor.&ZeroWidthSpace;podTargetLabels | list | `[]` |  |
 | ingester.&ZeroWidthSpace;serviceMonitor.&ZeroWidthSpace;relabelings | list | `[]` |  |
 | ingester.&ZeroWidthSpace;startupProbe | object | `{}` | Startup/liveness probes for ingesters are not recommended.  Ref: https://cortexmetrics.io/docs/guides/running-cortex-on-kubernetes/#take-extra-care-with-ingesters |
 | ingester.&ZeroWidthSpace;statefulSet.&ZeroWidthSpace;enabled | bool | `false` | If true, use a statefulset instead of a deployment for pod management. This is useful when using WAL |
@@ -506,6 +510,7 @@ Kubernetes: `^1.19.0-0`
 | overrides_exporter.&ZeroWidthSpace;serviceMonitor.&ZeroWidthSpace;enabled | bool | `false` |  |
 | overrides_exporter.&ZeroWidthSpace;serviceMonitor.&ZeroWidthSpace;extraEndpointSpec | object | `{}` | Additional endpoint configuration https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#endpoint |
 | overrides_exporter.&ZeroWidthSpace;serviceMonitor.&ZeroWidthSpace;metricRelabelings | list | `[]` |  |
+| overrides_exporter.&ZeroWidthSpace;serviceMonitor.&ZeroWidthSpace;podTargetLabels | list | `[]` |  |
 | overrides_exporter.&ZeroWidthSpace;serviceMonitor.&ZeroWidthSpace;relabelings | list | `[]` |  |
 | overrides_exporter.&ZeroWidthSpace;startupProbe.&ZeroWidthSpace;failureThreshold | int | `10` |  |
 | overrides_exporter.&ZeroWidthSpace;startupProbe.&ZeroWidthSpace;httpGet.&ZeroWidthSpace;path | string | `"/ready"` |  |
@@ -548,6 +553,7 @@ Kubernetes: `^1.19.0-0`
 | purger.&ZeroWidthSpace;serviceMonitor.&ZeroWidthSpace;enabled | bool | `false` |  |
 | purger.&ZeroWidthSpace;serviceMonitor.&ZeroWidthSpace;extraEndpointSpec | object | `{}` |  |
 | purger.&ZeroWidthSpace;serviceMonitor.&ZeroWidthSpace;metricRelabelings | list | `[]` |  |
+| purger.&ZeroWidthSpace;serviceMonitor.&ZeroWidthSpace;podTargetLabels | list | `[]` |  |
 | purger.&ZeroWidthSpace;serviceMonitor.&ZeroWidthSpace;relabelings | list | `[]` |  |
 | purger.&ZeroWidthSpace;startupProbe.&ZeroWidthSpace;failureThreshold | int | `60` |  |
 | purger.&ZeroWidthSpace;startupProbe.&ZeroWidthSpace;httpGet.&ZeroWidthSpace;path | string | `"/ready"` |  |
@@ -600,6 +606,7 @@ Kubernetes: `^1.19.0-0`
 | querier.&ZeroWidthSpace;serviceMonitor.&ZeroWidthSpace;enabled | bool | `false` |  |
 | querier.&ZeroWidthSpace;serviceMonitor.&ZeroWidthSpace;extraEndpointSpec | object | `{}` | Additional endpoint configuration https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#endpoint |
 | querier.&ZeroWidthSpace;serviceMonitor.&ZeroWidthSpace;metricRelabelings | list | `[]` |  |
+| querier.&ZeroWidthSpace;serviceMonitor.&ZeroWidthSpace;podTargetLabels | list | `[]` |  |
 | querier.&ZeroWidthSpace;serviceMonitor.&ZeroWidthSpace;relabelings | list | `[]` |  |
 | querier.&ZeroWidthSpace;startupProbe.&ZeroWidthSpace;failureThreshold | int | `10` |  |
 | querier.&ZeroWidthSpace;startupProbe.&ZeroWidthSpace;httpGet.&ZeroWidthSpace;path | string | `"/ready"` |  |
@@ -646,6 +653,7 @@ Kubernetes: `^1.19.0-0`
 | query_frontend.&ZeroWidthSpace;serviceMonitor.&ZeroWidthSpace;enabled | bool | `false` |  |
 | query_frontend.&ZeroWidthSpace;serviceMonitor.&ZeroWidthSpace;extraEndpointSpec | object | `{}` | Additional endpoint configuration https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#endpoint |
 | query_frontend.&ZeroWidthSpace;serviceMonitor.&ZeroWidthSpace;metricRelabelings | list | `[]` |  |
+| query_frontend.&ZeroWidthSpace;serviceMonitor.&ZeroWidthSpace;podTargetLabels | list | `[]` |  |
 | query_frontend.&ZeroWidthSpace;serviceMonitor.&ZeroWidthSpace;relabelings | list | `[]` |  |
 | query_frontend.&ZeroWidthSpace;startupProbe.&ZeroWidthSpace;failureThreshold | int | `10` |  |
 | query_frontend.&ZeroWidthSpace;startupProbe.&ZeroWidthSpace;httpGet.&ZeroWidthSpace;path | string | `"/ready"` |  |
@@ -691,6 +699,7 @@ Kubernetes: `^1.19.0-0`
 | query_scheduler.&ZeroWidthSpace;serviceMonitor.&ZeroWidthSpace;enabled | bool | `false` |  |
 | query_scheduler.&ZeroWidthSpace;serviceMonitor.&ZeroWidthSpace;extraEndpointSpec | object | `{}` | Additional endpoint configuration https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#endpoint |
 | query_scheduler.&ZeroWidthSpace;serviceMonitor.&ZeroWidthSpace;metricRelabelings | list | `[]` |  |
+| query_scheduler.&ZeroWidthSpace;serviceMonitor.&ZeroWidthSpace;podTargetLabels | list | `[]` |  |
 | query_scheduler.&ZeroWidthSpace;serviceMonitor.&ZeroWidthSpace;relabelings | list | `[]` |  |
 | query_scheduler.&ZeroWidthSpace;startupProbe.&ZeroWidthSpace;failureThreshold | int | `10` |  |
 | query_scheduler.&ZeroWidthSpace;startupProbe.&ZeroWidthSpace;httpGet.&ZeroWidthSpace;path | string | `"/ready"` |  |
@@ -738,6 +747,7 @@ Kubernetes: `^1.19.0-0`
 | ruler.&ZeroWidthSpace;serviceMonitor.&ZeroWidthSpace;enabled | bool | `false` |  |
 | ruler.&ZeroWidthSpace;serviceMonitor.&ZeroWidthSpace;extraEndpointSpec | object | `{}` | Additional endpoint configuration https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#endpoint |
 | ruler.&ZeroWidthSpace;serviceMonitor.&ZeroWidthSpace;metricRelabelings | list | `[]` |  |
+| ruler.&ZeroWidthSpace;serviceMonitor.&ZeroWidthSpace;podTargetLabels | list | `[]` |  |
 | ruler.&ZeroWidthSpace;serviceMonitor.&ZeroWidthSpace;relabelings | list | `[]` |  |
 | ruler.&ZeroWidthSpace;sidecar.&ZeroWidthSpace;containerSecurityContext.&ZeroWidthSpace;enabled | bool | `true` |  |
 | ruler.&ZeroWidthSpace;sidecar.&ZeroWidthSpace;containerSecurityContext.&ZeroWidthSpace;readOnlyRootFilesystem | bool | `true` |  |
@@ -821,6 +831,7 @@ Kubernetes: `^1.19.0-0`
 | store_gateway.&ZeroWidthSpace;serviceMonitor.&ZeroWidthSpace;enabled | bool | `false` |  |
 | store_gateway.&ZeroWidthSpace;serviceMonitor.&ZeroWidthSpace;extraEndpointSpec | object | `{}` | Additional endpoint configuration https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#endpoint |
 | store_gateway.&ZeroWidthSpace;serviceMonitor.&ZeroWidthSpace;metricRelabelings | list | `[]` |  |
+| store_gateway.&ZeroWidthSpace;serviceMonitor.&ZeroWidthSpace;podTargetLabels | list | `[]` |  |
 | store_gateway.&ZeroWidthSpace;serviceMonitor.&ZeroWidthSpace;relabelings | list | `[]` |  |
 | store_gateway.&ZeroWidthSpace;startupProbe.&ZeroWidthSpace;failureThreshold | int | `60` |  |
 | store_gateway.&ZeroWidthSpace;startupProbe.&ZeroWidthSpace;httpGet.&ZeroWidthSpace;path | string | `"/ready"` |  |

--- a/templates/alertmanager/alertmanager-servicemonitor.yaml
+++ b/templates/alertmanager/alertmanager-servicemonitor.yaml
@@ -20,6 +20,12 @@ spec:
   namespaceSelector:
     matchNames:
       - {{ .Release.Namespace | quote }}
+  {{- if .Values.purger.serviceMonitor.podTargetLabels }}
+  podTargetLabels:
+  {{- range .Values.purger.serviceMonitor.podTargetLabels }}
+    - {{ . }}
+  {{- end }}
+  {{- end }}
   endpoints:
   - port: http-metrics
     {{- if .Values.alertmanager.serviceMonitor.interval }}

--- a/templates/compactor/compactor-servicemonitor.yaml
+++ b/templates/compactor/compactor-servicemonitor.yaml
@@ -20,6 +20,12 @@ spec:
   namespaceSelector:
     matchNames:
       - {{ .Release.Namespace | quote }}
+  {{- if .Values.purger.serviceMonitor.podTargetLabels }}
+  podTargetLabels:
+  {{- range .Values.purger.serviceMonitor.podTargetLabels }}
+    - {{ . }}
+  {{- end }}
+  {{- end }}
   endpoints:
   - port: http-metrics
     {{- if .Values.compactor.serviceMonitor.interval }}

--- a/templates/distributor/distributor-servicemonitor.yaml
+++ b/templates/distributor/distributor-servicemonitor.yaml
@@ -20,6 +20,12 @@ spec:
   namespaceSelector:
     matchNames:
       - {{ .Release.Namespace | quote }}
+  {{- if .Values.purger.serviceMonitor.podTargetLabels }}
+  podTargetLabels:
+  {{- range .Values.purger.serviceMonitor.podTargetLabels }}
+    - {{ . }}
+  {{- end }}
+  {{- end }}
   endpoints:
   - port: http-metrics
     {{- if .Values.distributor.serviceMonitor.interval }}

--- a/templates/ingester/ingester-servicemonitor.yaml
+++ b/templates/ingester/ingester-servicemonitor.yaml
@@ -20,6 +20,12 @@ spec:
   namespaceSelector:
     matchNames:
       - {{ .Release.Namespace | quote }}
+  {{- if .Values.purger.serviceMonitor.podTargetLabels }}
+  podTargetLabels:
+  {{- range .Values.purger.serviceMonitor.podTargetLabels }}
+    - {{ . }}
+  {{- end }}
+  {{- end }}
   endpoints:
   - port: http-metrics
     {{- if .Values.ingester.serviceMonitor.interval }}

--- a/templates/overrides-exporter/overrides-exporter-servicemonitor.yaml
+++ b/templates/overrides-exporter/overrides-exporter-servicemonitor.yaml
@@ -20,6 +20,12 @@ spec:
   namespaceSelector:
     matchNames:
       - {{ .Release.Namespace | quote }}
+  {{- if .Values.purger.serviceMonitor.podTargetLabels }}
+  podTargetLabels:
+  {{- range .Values.purger.serviceMonitor.podTargetLabels }}
+    - {{ . }}
+  {{- end }}
+  {{- end }}
   endpoints:
   - port: http-metrics
     {{- if .Values.overrides_exporter.serviceMonitor.interval }}

--- a/templates/purger/purger-servicemonitor.yaml
+++ b/templates/purger/purger-servicemonitor.yaml
@@ -20,6 +20,12 @@ spec:
   namespaceSelector:
     matchNames:
       - {{ .Release.Namespace | quote }}
+  {{- if .Values.purger.serviceMonitor.podTargetLabels }}
+  podTargetLabels:
+  {{- range .Values.purger.serviceMonitor.podTargetLabels }}
+    - {{ . }}
+  {{- end }}
+  {{- end }}
   endpoints:
   - port: http-metrics
     {{- if .Values.purger.serviceMonitor.interval }}

--- a/templates/querier/querier-servicemonitor.yaml
+++ b/templates/querier/querier-servicemonitor.yaml
@@ -20,6 +20,12 @@ spec:
   namespaceSelector:
     matchNames:
       - {{ .Release.Namespace | quote }}
+  {{- if .Values.purger.serviceMonitor.podTargetLabels }}
+  podTargetLabels:
+  {{- range .Values.purger.serviceMonitor.podTargetLabels }}
+    - {{ . }}
+  {{- end }}
+  {{- end }}
   endpoints:
   - port: http-metrics
     {{- if .Values.querier.serviceMonitor.interval }}

--- a/templates/query-frontend/query-frontend-servicemonitor.yaml
+++ b/templates/query-frontend/query-frontend-servicemonitor.yaml
@@ -20,6 +20,12 @@ spec:
   namespaceSelector:
     matchNames:
       - {{ .Release.Namespace | quote }}
+  {{- if .Values.purger.serviceMonitor.podTargetLabels }}
+  podTargetLabels:
+  {{- range .Values.purger.serviceMonitor.podTargetLabels }}
+    - {{ . }}
+  {{- end }}
+  {{- end }}
   endpoints:
   - port: http-metrics
     {{- if .Values.query_frontend.serviceMonitor.interval }}

--- a/templates/query-scheduler/query-scheduler-servicemonitor.yaml
+++ b/templates/query-scheduler/query-scheduler-servicemonitor.yaml
@@ -20,6 +20,12 @@ spec:
   namespaceSelector:
     matchNames:
       - {{ .Release.Namespace | quote }}
+  {{- if .Values.purger.serviceMonitor.podTargetLabels }}
+  podTargetLabels:
+  {{- range .Values.purger.serviceMonitor.podTargetLabels }}
+    - {{ . }}
+  {{- end }}
+  {{- end }}
   endpoints:
   - port: http-metrics
     {{- if .Values.query_scheduler.serviceMonitor.interval }}

--- a/templates/ruler/ruler-servicemonitor.yaml
+++ b/templates/ruler/ruler-servicemonitor.yaml
@@ -20,6 +20,12 @@ spec:
   namespaceSelector:
     matchNames:
       - {{ .Release.Namespace | quote }}
+  {{- if .Values.purger.serviceMonitor.podTargetLabels }}
+  podTargetLabels:
+  {{- range .Values.purger.serviceMonitor.podTargetLabels }}
+    - {{ . }}
+  {{- end }}
+  {{- end }}
   endpoints:
   - port: http-metrics
     {{- if .Values.ruler.serviceMonitor.interval }}

--- a/templates/store-gateway/store-gateway-servicemonitor.yaml
+++ b/templates/store-gateway/store-gateway-servicemonitor.yaml
@@ -20,6 +20,12 @@ spec:
   namespaceSelector:
     matchNames:
       - {{ .Release.Namespace | quote }}
+  {{- if .Values.purger.serviceMonitor.podTargetLabels }}
+  podTargetLabels:
+  {{- range .Values.purger.serviceMonitor.podTargetLabels }}
+    - {{ . }}
+  {{- end }}
+  {{- end }}
   endpoints:
   - port: http-metrics
     {{- if .Values.store_gateway.serviceMonitor.interval }}

--- a/values.yaml
+++ b/values.yaml
@@ -167,6 +167,7 @@ alertmanager:
     metricRelabelings: []
     # -- Additional endpoint configuration https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#endpoint
     extraEndpointSpec: {}
+    podTargetLabels: []
 
   resources: {}
 
@@ -330,6 +331,7 @@ distributor:
     metricRelabelings: []
     # -- Additional endpoint configuration https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#endpoint
     extraEndpointSpec: {}
+    podTargetLabels: []
 
   resources: {}
 
@@ -440,6 +442,7 @@ ingester:
     metricRelabelings: []
     # -- Additional endpoint configuration https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#endpoint
     extraEndpointSpec: {}
+    podTargetLabels: []
 
   resources: {}
 
@@ -592,6 +595,7 @@ ruler:
     metricRelabelings: []
     # -- Additional endpoint configuration https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#endpoint
     extraEndpointSpec: {}
+    podTargetLabels: []
 
   resources: {}
 
@@ -728,6 +732,7 @@ querier:
     metricRelabelings: []
     # -- Additional endpoint configuration https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#endpoint
     extraEndpointSpec: {}
+    podTargetLabels: []
 
   resources: {}
 
@@ -832,6 +837,7 @@ query_frontend:
     metricRelabelings: []
     # -- Additional endpoint configuration https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#endpoint
     extraEndpointSpec: {}
+    podTargetLabels: []
 
   resources: {}
 
@@ -922,6 +928,7 @@ query_scheduler:
     metricRelabelings: []
     # -- Additional endpoint configuration https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#endpoint
     extraEndpointSpec: {}
+    podTargetLabels: []
 
   resources: {}
 
@@ -1010,6 +1017,7 @@ overrides_exporter:
     metricRelabelings: []
     # -- Additional endpoint configuration https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#endpoint
     extraEndpointSpec: {}
+    podTargetLabels: []
 
   resources: {}
 
@@ -1095,6 +1103,7 @@ purger:
     relabelings: []
     metricRelabelings: []
     extraEndpointSpec: {}
+    podTargetLabels: []
 
   resources: {}
 
@@ -1306,6 +1315,7 @@ store_gateway:
     metricRelabelings: []
     # -- Additional endpoint configuration https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#endpoint
     extraEndpointSpec: {}
+    podTargetLabels: []
 
   resources: {}
 
@@ -1433,6 +1443,7 @@ compactor:
     metricRelabelings: []
     # -- Additional endpoint configuration https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#endpoint
     extraEndpointSpec: {}
+    podTargetLabels: []
 
   resources: {}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
3. Please do not edit/bump the Chart.yaml "version" field
-->

**What this PR does**: Adds podTargetLabels to the main values.yaml as an option to add to your servicemonitors. This allows pod labels to get added to metrics being collected.

**Which issue(s) this PR fixes**:
Fixes #437

**Checklist**
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`