### PR TITLE
Correctly interpret .Capabilities.KubeVersion when it looks like a prerelease

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## master / unreleased
 
 * [DEPENDENCY] Update quay.io/cortexproject/cortex Docker tag to v1.15.0 #453
+* [BUGFIX] Correctly interpret .Capabilities.KubeVersion when it looks like a prerelease #457
 
 ## 2.1.0 / 2023-03-17
 

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -112,7 +112,7 @@ Create configuration for frontend memcached configuration
 Determine the policy api version
 */}}
 {{- define "cortex.pdbVersion" -}}
-{{- if or (.Capabilities.APIVersions.Has "policy/v1/PodDisruptionBudget") (semverCompare ">=1.21" .Capabilities.KubeVersion.Version) -}}
+{{- if or (.Capabilities.APIVersions.Has "policy/v1/PodDisruptionBudget") (semverCompare ">=1.21-0" .Capabilities.KubeVersion.Version) -}}
 policy/v1
 {{- else -}}
 policy/v1beta1
@@ -153,7 +153,7 @@ Get volume of config secret of configMap
 Get cortex hpa version by k8s version
 */}}
 {{- define "cortex.hpaVersion" -}}
-{{- if or (.Capabilities.APIVersions.Has "autoscaling/v2/HorizontalPodAutoscaler") (semverCompare ">=1.23" .Capabilities.KubeVersion.Version) -}}
+{{- if or (.Capabilities.APIVersions.Has "autoscaling/v2/HorizontalPodAutoscaler") (semverCompare ">=1.23-0" .Capabilities.KubeVersion.Version) -}}
 autoscaling/v2
 {{- else -}}
 autoscaling/v2beta2


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
3. Please do not edit/bump the Chart.yaml "version" field
-->

**What this PR does**:
The chart uses `semverCompare` to interpret `.Capabilties.KubeVersion`. `semverCompare` by default will ignore prereleases. A Kubernetes prerelease will still support the newer API versions targeted for that release, so the chart should allow prereleases when doing version comparisons.

Moreover, popular Kubernetes releases such as AWS EKS [improperly] use prerelease annotation in their version strings, like `1.25.8-eks-ec5523e`, so this issue could cause incorrect API versions to be selected on those clusters.

`semverCompare` supports allowing prereleases by adding `-0` to the operand, like `>=1.21-0`.

This PR adds `-0` to the version comparison so that versions that look like prereleases are supported.

References:
* https://semver.org/
* https://github.com/Masterminds/semver#working-with-prerelease-versions

**Which issue(s) this PR fixes**:
Fixes #160

**Checklist**
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`