### PR TITLE
fix podTargetLabels in all Prometheus ServiceMonitor CRDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * [DEPENDENCY] Update quay.io/cortexproject/cortex Docker tag to v1.15.2 #459
 * [DEPENDENCY] Update quay.io/cortexproject/cortex Docker tag to v1.15.3 #471
 * [BUGFIX] Correctly interpret .Capabilities.KubeVersion when it looks like a prerelease #457
+* [BUGFIX] Fix podTargetLabels in all Prometheus ServiceMonitor CRD's #
 
 ## 2.1.0 / 2023-03-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 * [DEPENDENCY] Update quay.io/cortexproject/cortex Docker tag to v1.15.2 #459
 * [DEPENDENCY] Update quay.io/cortexproject/cortex Docker tag to v1.15.3 #471
 * [BUGFIX] Correctly interpret .Capabilities.KubeVersion when it looks like a prerelease #457
-* [BUGFIX] Fix podTargetLabels in all Prometheus ServiceMonitor CRD's #
+* [BUGFIX] Fix podTargetLabels in all Prometheus ServiceMonitor CRDs #487
 
 ## 2.1.0 / 2023-03-17
 

--- a/templates/alertmanager/alertmanager-servicemonitor.yaml
+++ b/templates/alertmanager/alertmanager-servicemonitor.yaml
@@ -20,9 +20,9 @@ spec:
   namespaceSelector:
     matchNames:
       - {{ .Release.Namespace | quote }}
-  {{- if .Values.purger.serviceMonitor.podTargetLabels }}
+  {{- if .Values.alertmanager.serviceMonitor.podTargetLabels }}
   podTargetLabels:
-  {{- range .Values.purger.serviceMonitor.podTargetLabels }}
+  {{- range .Values.alertmanager.serviceMonitor.podTargetLabels }}
     - {{ . }}
   {{- end }}
   {{- end }}

--- a/templates/compactor/compactor-servicemonitor.yaml
+++ b/templates/compactor/compactor-servicemonitor.yaml
@@ -20,9 +20,9 @@ spec:
   namespaceSelector:
     matchNames:
       - {{ .Release.Namespace | quote }}
-  {{- if .Values.purger.serviceMonitor.podTargetLabels }}
+  {{- if .Values.compactor.serviceMonitor.podTargetLabels }}
   podTargetLabels:
-  {{- range .Values.purger.serviceMonitor.podTargetLabels }}
+  {{- range .Values.compactor.serviceMonitor.podTargetLabels }}
     - {{ . }}
   {{- end }}
   {{- end }}

--- a/templates/distributor/distributor-servicemonitor.yaml
+++ b/templates/distributor/distributor-servicemonitor.yaml
@@ -20,9 +20,9 @@ spec:
   namespaceSelector:
     matchNames:
       - {{ .Release.Namespace | quote }}
-  {{- if .Values.purger.serviceMonitor.podTargetLabels }}
+  {{- if .Values.distributor.serviceMonitor.podTargetLabels }}
   podTargetLabels:
-  {{- range .Values.purger.serviceMonitor.podTargetLabels }}
+  {{- range .Values.distributor.serviceMonitor.podTargetLabels }}
     - {{ . }}
   {{- end }}
   {{- end }}

--- a/templates/ingester/ingester-servicemonitor.yaml
+++ b/templates/ingester/ingester-servicemonitor.yaml
@@ -20,9 +20,9 @@ spec:
   namespaceSelector:
     matchNames:
       - {{ .Release.Namespace | quote }}
-  {{- if .Values.purger.serviceMonitor.podTargetLabels }}
+  {{- if .Values.ingester.serviceMonitor.podTargetLabels }}
   podTargetLabels:
-  {{- range .Values.purger.serviceMonitor.podTargetLabels }}
+  {{- range .Values.ingester.serviceMonitor.podTargetLabels }}
     - {{ . }}
   {{- end }}
   {{- end }}

--- a/templates/overrides-exporter/overrides-exporter-servicemonitor.yaml
+++ b/templates/overrides-exporter/overrides-exporter-servicemonitor.yaml
@@ -20,9 +20,9 @@ spec:
   namespaceSelector:
     matchNames:
       - {{ .Release.Namespace | quote }}
-  {{- if .Values.purger.serviceMonitor.podTargetLabels }}
+  {{- if .Values.overrides_exporter.serviceMonitor.podTargetLabels }}
   podTargetLabels:
-  {{- range .Values.purger.serviceMonitor.podTargetLabels }}
+  {{- range .Values.overrides_exporter.serviceMonitor.podTargetLabels }}
     - {{ . }}
   {{- end }}
   {{- end }}

--- a/templates/querier/querier-servicemonitor.yaml
+++ b/templates/querier/querier-servicemonitor.yaml
@@ -20,9 +20,9 @@ spec:
   namespaceSelector:
     matchNames:
       - {{ .Release.Namespace | quote }}
-  {{- if .Values.purger.serviceMonitor.podTargetLabels }}
+  {{- if .Values.querier.serviceMonitor.podTargetLabels }}
   podTargetLabels:
-  {{- range .Values.purger.serviceMonitor.podTargetLabels }}
+  {{- range .Values.querier.serviceMonitor.podTargetLabels }}
     - {{ . }}
   {{- end }}
   {{- end }}

--- a/templates/query-frontend/query-frontend-servicemonitor.yaml
+++ b/templates/query-frontend/query-frontend-servicemonitor.yaml
@@ -20,9 +20,9 @@ spec:
   namespaceSelector:
     matchNames:
       - {{ .Release.Namespace | quote }}
-  {{- if .Values.purger.serviceMonitor.podTargetLabels }}
+  {{- if .Values.query_frontend.serviceMonitor.podTargetLabels }}
   podTargetLabels:
-  {{- range .Values.purger.serviceMonitor.podTargetLabels }}
+  {{- range .Values.query_frontend.serviceMonitor.podTargetLabels }}
     - {{ . }}
   {{- end }}
   {{- end }}

--- a/templates/query-scheduler/query-scheduler-servicemonitor.yaml
+++ b/templates/query-scheduler/query-scheduler-servicemonitor.yaml
@@ -20,9 +20,9 @@ spec:
   namespaceSelector:
     matchNames:
       - {{ .Release.Namespace | quote }}
-  {{- if .Values.purger.serviceMonitor.podTargetLabels }}
+  {{- if .Values.query_scheduler.serviceMonitor.podTargetLabels }}
   podTargetLabels:
-  {{- range .Values.purger.serviceMonitor.podTargetLabels }}
+  {{- range .Values.query_scheduler.serviceMonitor.podTargetLabels }}
     - {{ . }}
   {{- end }}
   {{- end }}

--- a/templates/ruler/ruler-servicemonitor.yaml
+++ b/templates/ruler/ruler-servicemonitor.yaml
@@ -20,9 +20,9 @@ spec:
   namespaceSelector:
     matchNames:
       - {{ .Release.Namespace | quote }}
-  {{- if .Values.purger.serviceMonitor.podTargetLabels }}
+  {{- if .Values.ruler.serviceMonitor.podTargetLabels }}
   podTargetLabels:
-  {{- range .Values.purger.serviceMonitor.podTargetLabels }}
+  {{- range .Values.ruler.serviceMonitor.podTargetLabels }}
     - {{ . }}
   {{- end }}
   {{- end }}

--- a/templates/store-gateway/store-gateway-servicemonitor.yaml
+++ b/templates/store-gateway/store-gateway-servicemonitor.yaml
@@ -20,9 +20,9 @@ spec:
   namespaceSelector:
     matchNames:
       - {{ .Release.Namespace | quote }}
-  {{- if .Values.purger.serviceMonitor.podTargetLabels }}
+  {{- if .Values.store_gateway.serviceMonitor.podTargetLabels }}
   podTargetLabels:
-  {{- range .Values.purger.serviceMonitor.podTargetLabels }}
+  {{- range .Values.store_gateway.serviceMonitor.podTargetLabels }}
     - {{ . }}
   {{- end }}
   {{- end }}


### PR DESCRIPTION
**What this PR does**:

I think we all messed-up a bit in PR #439. I randomly found this. Previously all podTargetLabels are the same as in the `purger`. Must have been a copy pasta error.

CC:
@jmeza-xyz 
@kd7lxl 

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`