### PR TITLE
🧹 Cleanup removed & legacy chunk config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## master / unreleased
 
+* [CHANGE] Removed `config.storage.engine` and any reference of it #488
 * [ENHANCEMENT] Add `appProtocol` field to templates/svc-memberlist-headless.yaml to fix issues wirth Istio #485
 * [ENHANCEMENT] Add option to autoscale on multiple metrics and custom metrics metrics #467
 * [ENHANCEMENT] Add control on store-gateway statefulset when autoscale (HPA) enabled or disabled #472
@@ -10,6 +11,7 @@
 * [DEPENDENCY] Update quay.io/cortexproject/cortex Docker tag to v1.15.2 #459
 * [DEPENDENCY] Update quay.io/cortexproject/cortex Docker tag to v1.15.3 #471
 * [BUGFIX] Correctly interpret .Capabilities.KubeVersion when it looks like a prerelease #457
+* [BUGFIX] Removed non-existent `purger.enable` flags in some components #488
 
 ## 2.1.0 / 2023-03-17
 

--- a/README.md
+++ b/README.md
@@ -256,7 +256,6 @@ Kubernetes: `^1.19.0-0`
 | config.&ZeroWidthSpace;server.&ZeroWidthSpace;grpc_server_max_recv_msg_size | int | `10485760` |  |
 | config.&ZeroWidthSpace;server.&ZeroWidthSpace;grpc_server_max_send_msg_size | int | `10485760` |  |
 | config.&ZeroWidthSpace;server.&ZeroWidthSpace;http_listen_port | int | `8080` |  |
-| config.&ZeroWidthSpace;storage | object | `{"engine":"blocks"}` | See https://github.com/cortexproject/cortex/blob/master/docs/configuration/config-file-reference.md#storage_config |
 | config.&ZeroWidthSpace;store_gateway | object | `{"sharding_enabled":false}` | https://cortexmetrics.io/docs/configuration/configuration-file/#store_gateway_config |
 | distributor.&ZeroWidthSpace;affinity.&ZeroWidthSpace;podAntiAffinity.&ZeroWidthSpace;preferredDuringSchedulingIgnoredDuringExecution[0].&ZeroWidthSpace;podAffinityTerm.&ZeroWidthSpace;labelSelector.&ZeroWidthSpace;matchExpressions[0].&ZeroWidthSpace;key | string | `"app.kubernetes.io/component"` |  |
 | distributor.&ZeroWidthSpace;affinity.&ZeroWidthSpace;podAntiAffinity.&ZeroWidthSpace;preferredDuringSchedulingIgnoredDuringExecution[0].&ZeroWidthSpace;podAffinityTerm.&ZeroWidthSpace;labelSelector.&ZeroWidthSpace;matchExpressions[0].&ZeroWidthSpace;operator | string | `"In"` |  |

--- a/ci/test-configmap-values.yaml
+++ b/ci/test-configmap-values.yaml
@@ -14,9 +14,6 @@ config:
         kvstore:
           store: "memberlist"
 
-  # See https://github.com/cortexproject/cortex/blob/master/docs/configuration/config-file-reference.md#storage_config
-  storage:
-    engine: blocks
   blocks_storage:
     backend: "filesystem"
     tsdb:

--- a/ci/test-deployment-values.yaml
+++ b/ci/test-deployment-values.yaml
@@ -12,9 +12,6 @@ config:
         kvstore:
           store: "memberlist"
 
-  # See https://github.com/cortexproject/cortex/blob/master/docs/configuration/config-file-reference.md#storage_config
-  storage:
-    engine: blocks
   blocks_storage:
     backend: "filesystem"
     tsdb:

--- a/ci/test-sts-values.yaml
+++ b/ci/test-sts-values.yaml
@@ -12,9 +12,6 @@ config:
         kvstore:
           store: "memberlist"
 
-  # See https://github.com/cortexproject/cortex/blob/master/docs/configuration/config-file-reference.md#storage_config
-  storage:
-    engine: blocks
   blocks_storage:
     backend: "filesystem"
     tsdb:

--- a/docs/guides/getting_started_with_block_storage.markdown
+++ b/docs/guides/getting_started_with_block_storage.markdown
@@ -29,8 +29,6 @@ config:
       bucket_name: # your bucket name
       region: us-east-1
       endpoint: s3.us-east-1.amazonaws.com
-  storage:
-    engine: blocks
   blocks_storage:
     backend: s3
     s3:

--- a/templates/NOTES.txt
+++ b/templates/NOTES.txt
@@ -1,9 +1,3 @@
-{{- if eq .Values.config.storage.engine "chunks" }}
-Cortex chunks storage has been deprecated, and it's now in maintenance mode: all Cortex users are encouraged to migrate to the blocks storage.
-No new features will be added to the chunks storage.
-Unlike the official cortex default configuration this helm-chart does not run the chunk engine by default.
-{{- end }}
-
 Verify the application is working by running these commands:
   kubectl --namespace {{ .Release.Namespace }} port-forward service/{{ include "cortex.querierFullname" . }} {{ .Values.config.server.http_listen_port }}
   curl http://127.0.0.1:{{ .Values.config.server.http_listen_port }}/services

--- a/templates/compactor/compactor-statefulset.yaml
+++ b/templates/compactor/compactor-statefulset.yaml
@@ -1,4 +1,3 @@
-{{- if eq .Values.config.storage.engine "blocks" -}}
 {{- if .Values.compactor.enabled -}}
 apiVersion: apps/v1
 kind: StatefulSet
@@ -141,5 +140,4 @@ spec:
           env:
             {{- toYaml .Values.compactor.env | nindent 12 }}
           {{- end }}
-{{- end -}}
 {{- end -}}

--- a/templates/compactor/compactor-svc.yaml
+++ b/templates/compactor/compactor-svc.yaml
@@ -1,4 +1,3 @@
-{{- if eq .Values.config.storage.engine "blocks" -}}
 {{- if .Values.compactor.enabled -}}
 apiVersion: v1
 kind: Service
@@ -21,5 +20,4 @@ spec:
       targetPort: http-metrics
   selector:
     {{- include "cortex.compactorSelectorLabels" . | nindent 4 }}
-{{- end -}}
 {{- end -}}

--- a/templates/purger/purger-svc.yaml
+++ b/templates/purger/purger-svc.yaml
@@ -1,4 +1,3 @@
-{{- if eq .Values.config.storage.engine "blocks" -}}
 {{- if .Values.purger.enabled -}}
 apiVersion: v1
 kind: Service
@@ -21,5 +20,4 @@ spec:
       targetPort: http-metrics
   selector:
     {{- include "cortex.purgerSelectorLabels" . | nindent 4 }}
-{{- end -}}
 {{- end -}}

--- a/templates/querier/querier-dep.yaml
+++ b/templates/querier/querier-dep.yaml
@@ -58,9 +58,6 @@ spec:
           {{- if and .Values.query_frontend.enabled (not .Values.query_scheduler.enabled) }}
             - "-querier.frontend-address={{ template "cortex.queryFrontendFullname" . }}-headless.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.config.server.grpc_listen_port }}"
           {{- end }}
-          {{- if .Values.purger.enabled }}
-            - "-purger.enable"
-          {{- end }}
           {{- include "cortex.memcached" . | nindent 12}}
           {{- range $key, $value := .Values.querier.extraArgs }}
             - "-{{ $key }}={{ $value }}"

--- a/templates/query-frontend/query-frontend-dep.yaml
+++ b/templates/query-frontend/query-frontend-dep.yaml
@@ -54,9 +54,6 @@ spec:
           {{- if .Values.query_scheduler.enabled }}
             - "-frontend.scheduler-address={{ template "cortex.querySchedulerFullname" . }}-headless.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.config.server.grpc_listen_port }}"
           {{- end }}
-          {{- if .Values.purger.enabled }}
-            - "-purger.enable"
-          {{- end }}
           {{- range $key, $value := .Values.query_frontend.extraArgs }}
             - "-{{ $key }}={{ $value }}"
           {{- end }}

--- a/templates/ruler/ruler-dep.yaml
+++ b/templates/ruler/ruler-dep.yaml
@@ -112,9 +112,6 @@ spec:
             - "-ruler.alertmanager-url=http://{{ template "cortex.alertmanagerFullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.config.server.http_listen_port }}/api/prom/alertmanager/"
               {{- end }}
             {{- end }}
-          {{- if .Values.purger.enabled }}
-            - "-purger.enable"
-          {{- end }}
             {{- include "cortex.memcached" . | nindent 12}}
           {{- range $key, $value := .Values.ruler.extraArgs }}
             - "-{{ $key }}={{ $value }}"

--- a/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/templates/store-gateway/store-gateway-statefulset.yaml
@@ -1,4 +1,4 @@
-{{- if and (eq .Values.config.storage.engine "blocks") (.Values.store_gateway.enabled) -}}
+{{- if .Values.store_gateway.enabled -}}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:

--- a/templates/store-gateway/store-gateway-svc-headless.yaml
+++ b/templates/store-gateway/store-gateway-svc-headless.yaml
@@ -1,4 +1,4 @@
-{{- if and (eq .Values.config.storage.engine "blocks") .Values.store_gateway.enabled -}}
+{{- if .Values.store_gateway.enabled -}}
 apiVersion: v1
 kind: Service
 metadata:

--- a/templates/store-gateway/store-gateway-svc.yaml
+++ b/templates/store-gateway/store-gateway-svc.yaml
@@ -1,4 +1,4 @@
-{{- if and (eq .Values.config.storage.engine "blocks") (.Values.store_gateway.enabled) -}}
+{{- if .Values.store_gateway.enabled -}}
 apiVersion: v1
 kind: Service
 metadata:

--- a/values.yaml
+++ b/values.yaml
@@ -76,9 +76,6 @@ config:
     grpc_client_config:
       max_recv_msg_size: 10485760
       max_send_msg_size: 10485760
-  # -- See https://github.com/cortexproject/cortex/blob/master/docs/configuration/config-file-reference.md#storage_config
-  storage:
-    engine: blocks
   blocks_storage:
     tsdb:
       dir: /data/tsdb
@@ -109,7 +106,7 @@ config:
     # form a ring and addresses are picked from the ring).
     # @default -- automatic
     store_gateway_addresses: |-
-      {{ if and (eq .Values.config.storage.engine "blocks") (not .Values.config.store_gateway.sharding_enabled) -}}
+      {{ if not .Values.config.store_gateway.sharding_enabled -}}
       dns+{{ include "cortex.storeGatewayFullname" $ }}-headless:9095
       {{- end }}
   query_range:


### PR DESCRIPTION
**What this PR does**:

1. Drops non-existent `purger.enable` flag for some components. I think they used to exists for chunk purger.
2. Removed any reference to `config.storage.engine` since `blocks` is the **only** option that is supported. Since there is nothing to configure, it's better to have no option to configure anything.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`