### PR TITLE
remove default livenessProbe for compactor and storage-gateway

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## master / unreleased
 
+* [CHANGE] Removed the default `livenessProbe` for store-gateway and compactor. You can still use a `livenessProbe` but we advise against it #502
 * [DEPENDENCY] Update quay.io/cortexproject/cortex Docker tag to v1.17.1 #501
 
 ## 2.3.0 / 2024-04-12

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ Kubernetes: `^1.19.0-0`
 | compactor.&ZeroWidthSpace;extraVolumeMounts | list | `[]` |  |
 | compactor.&ZeroWidthSpace;extraVolumes | list | `[]` |  |
 | compactor.&ZeroWidthSpace;initContainers | list | `[]` |  |
-| compactor.&ZeroWidthSpace;livenessProbe | list | `[]` |  |
+| compactor.&ZeroWidthSpace;livenessProbe | object | `{}` |  |
 | compactor.&ZeroWidthSpace;nodeSelector | object | `{}` |  |
 | compactor.&ZeroWidthSpace;persistentVolume.&ZeroWidthSpace;accessModes | list | `["ReadWriteOnce"]` | compactor data Persistent Volume access modes Must match those of existing PV or dynamic provisioner Ref: http://kubernetes.io/docs/user-guide/persistent-volumes/ |
 | compactor.&ZeroWidthSpace;persistentVolume.&ZeroWidthSpace;annotations | object | `{}` | compactor data Persistent Volume Claim annotations |
@@ -809,7 +809,7 @@ Kubernetes: `^1.19.0-0`
 | store_gateway.&ZeroWidthSpace;extraVolumeMounts | list | `[]` |  |
 | store_gateway.&ZeroWidthSpace;extraVolumes | list | `[]` |  |
 | store_gateway.&ZeroWidthSpace;initContainers | list | `[]` |  |
-| store_gateway.&ZeroWidthSpace;livenessProbe | list | `[]` |  |
+| store_gateway.&ZeroWidthSpace;livenessProbe | object | `{}` |  |
 | store_gateway.&ZeroWidthSpace;nodeSelector | object | `{}` |  |
 | store_gateway.&ZeroWidthSpace;persistentVolume.&ZeroWidthSpace;accessModes | list | `["ReadWriteOnce"]` | Store-gateway data Persistent Volume access modes Must match those of existing PV or dynamic provisioner Ref: http://kubernetes.io/docs/user-guide/persistent-volumes/ |
 | store_gateway.&ZeroWidthSpace;persistentVolume.&ZeroWidthSpace;annotations | object | `{}` | Store-gateway data Persistent Volume Claim annotations |

--- a/README.md
+++ b/README.md
@@ -179,9 +179,7 @@ Kubernetes: `^1.19.0-0`
 | compactor.&ZeroWidthSpace;extraVolumeMounts | list | `[]` |  |
 | compactor.&ZeroWidthSpace;extraVolumes | list | `[]` |  |
 | compactor.&ZeroWidthSpace;initContainers | list | `[]` |  |
-| compactor.&ZeroWidthSpace;livenessProbe.&ZeroWidthSpace;httpGet.&ZeroWidthSpace;path | string | `"/ready"` |  |
-| compactor.&ZeroWidthSpace;livenessProbe.&ZeroWidthSpace;httpGet.&ZeroWidthSpace;port | string | `"http-metrics"` |  |
-| compactor.&ZeroWidthSpace;livenessProbe.&ZeroWidthSpace;httpGet.&ZeroWidthSpace;scheme | string | `"HTTP"` |  |
+| compactor.&ZeroWidthSpace;livenessProbe | list | `[]` |  |
 | compactor.&ZeroWidthSpace;nodeSelector | object | `{}` |  |
 | compactor.&ZeroWidthSpace;persistentVolume.&ZeroWidthSpace;accessModes | list | `["ReadWriteOnce"]` | compactor data Persistent Volume access modes Must match those of existing PV or dynamic provisioner Ref: http://kubernetes.io/docs/user-guide/persistent-volumes/ |
 | compactor.&ZeroWidthSpace;persistentVolume.&ZeroWidthSpace;annotations | object | `{}` | compactor data Persistent Volume Claim annotations |
@@ -811,9 +809,7 @@ Kubernetes: `^1.19.0-0`
 | store_gateway.&ZeroWidthSpace;extraVolumeMounts | list | `[]` |  |
 | store_gateway.&ZeroWidthSpace;extraVolumes | list | `[]` |  |
 | store_gateway.&ZeroWidthSpace;initContainers | list | `[]` |  |
-| store_gateway.&ZeroWidthSpace;livenessProbe.&ZeroWidthSpace;httpGet.&ZeroWidthSpace;path | string | `"/ready"` |  |
-| store_gateway.&ZeroWidthSpace;livenessProbe.&ZeroWidthSpace;httpGet.&ZeroWidthSpace;port | string | `"http-metrics"` |  |
-| store_gateway.&ZeroWidthSpace;livenessProbe.&ZeroWidthSpace;httpGet.&ZeroWidthSpace;scheme | string | `"HTTP"` |  |
+| store_gateway.&ZeroWidthSpace;livenessProbe | list | `[]` |  |
 | store_gateway.&ZeroWidthSpace;nodeSelector | object | `{}` |  |
 | store_gateway.&ZeroWidthSpace;persistentVolume.&ZeroWidthSpace;accessModes | list | `["ReadWriteOnce"]` | Store-gateway data Persistent Volume access modes Must match those of existing PV or dynamic provisioner Ref: http://kubernetes.io/docs/user-guide/persistent-volumes/ |
 | store_gateway.&ZeroWidthSpace;persistentVolume.&ZeroWidthSpace;annotations | object | `{}` | Store-gateway data Persistent Volume Claim annotations |

--- a/templates/compactor/compactor-statefulset.yaml
+++ b/templates/compactor/compactor-statefulset.yaml
@@ -127,8 +127,10 @@ spec:
               protocol: TCP
           startupProbe:
             {{- toYaml .Values.compactor.startupProbe | nindent 12 }}
+          {{- if .Values.compactor.livenessProbe }}
           livenessProbe:
             {{- toYaml .Values.compactor.livenessProbe | nindent 12 }}
+          {{- end }}
           readinessProbe:
             {{- toYaml .Values.compactor.readinessProbe | nindent 12 }}
           resources:

--- a/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/templates/store-gateway/store-gateway-statefulset.yaml
@@ -133,8 +133,10 @@ spec:
               protocol: TCP
           startupProbe:
             {{- toYaml .Values.store_gateway.startupProbe | nindent 12 }}
+          {{- if .Values.store_gateway.livenessProbe }}
           livenessProbe:
             {{- toYaml .Values.store_gateway.livenessProbe | nindent 12 }}
+          {{- end }}
           readinessProbe:
             {{- toYaml .Values.store_gateway.readinessProbe | nindent 12 }}
           resources:

--- a/values.yaml
+++ b/values.yaml
@@ -1410,11 +1410,7 @@ store_gateway:
       path: /ready
       port: http-metrics
       scheme: HTTP
-  livenessProbe:
-    httpGet:
-      path: /ready
-      port: http-metrics
-      scheme: HTTP
+  livenessProbe: []
   readinessProbe:
     httpGet:
       path: /ready
@@ -1530,11 +1526,7 @@ compactor:
       path: /ready
       port: http-metrics
       scheme: HTTP
-  livenessProbe:
-    httpGet:
-      path: /ready
-      port: http-metrics
-      scheme: HTTP
+  livenessProbe: []
   readinessProbe:
     httpGet:
       path: /ready

--- a/values.yaml
+++ b/values.yaml
@@ -1410,7 +1410,7 @@ store_gateway:
       path: /ready
       port: http-metrics
       scheme: HTTP
-  livenessProbe: []
+  livenessProbe: {}
   readinessProbe:
     httpGet:
       path: /ready
@@ -1526,7 +1526,7 @@ compactor:
       path: /ready
       port: http-metrics
       scheme: HTTP
-  livenessProbe: []
+  livenessProbe: {}
   readinessProbe:
     httpGet:
       path: /ready


### PR DESCRIPTION
**What this PR does**:

Removes the default livenessProbe for compactor and storage-gateway. You can still specify a `livenessProbe` if this is desired.

As discussed in #484


**Which issue(s) this PR fixes**:
Fixes #484

**Checklist**
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`