### PR TITLE
Add the possibility to configure the upstream protocol in the nginx configuration for the cortex upstream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master / unreleased
 
+* [ENHANCEMENT] Add `nginx.config.upstream_protocol` field to configure the upstream protocol in the nginx configuration #506
+
 ## 2.4.0 / 2024-07-18
 
 * [CHANGE] Removed the default `livenessProbe` for store-gateway and compactor. You can still use a `livenessProbe` but we advise against it #502

--- a/README.md
+++ b/README.md
@@ -439,6 +439,7 @@ Kubernetes: `^1.19.0-0`
 | nginx.&ZeroWidthSpace;config.&ZeroWidthSpace;mainSnippet | string | `""` | arbitrary snippet to inject in the top section of the nginx config |
 | nginx.&ZeroWidthSpace;config.&ZeroWidthSpace;serverSnippet | string | `""` | arbitrary snippet to inject in the server { } section of the nginx config |
 | nginx.&ZeroWidthSpace;config.&ZeroWidthSpace;setHeaders | object | `{}` |  |
+| nginx.&ZeroWidthSpace;config.&ZeroWidthSpace;upstream_protocol | string | `"http"` | protocol for the communication with the upstream |
 | nginx.&ZeroWidthSpace;config.&ZeroWidthSpace;verboseLogging | bool | `true` | Enables all access logs from nginx, otherwise ignores 2XX and 3XX status codes |
 | nginx.&ZeroWidthSpace;containerSecurityContext.&ZeroWidthSpace;enabled | bool | `true` |  |
 | nginx.&ZeroWidthSpace;containerSecurityContext.&ZeroWidthSpace;readOnlyRootFilesystem | bool | `false` |  |

--- a/templates/nginx/nginx-config.yaml
+++ b/templates/nginx/nginx-config.yaml
@@ -81,20 +81,20 @@ data:
 
         # Distributor Config
         location = /ring {
-          proxy_pass      http://{{ template "cortex.fullname" . }}-distributor.{{ $rootDomain }}$request_uri;
+          proxy_pass      {{ .Values.nginx.config.upstream_protocol }}://{{ template "cortex.fullname" . }}-distributor.{{ $rootDomain }}$request_uri;
         }
 
         location = /all_user_stats {
-          proxy_pass      http://{{ template "cortex.fullname" . }}-distributor.{{ $rootDomain }}$request_uri;
+          proxy_pass      {{ .Values.nginx.config.upstream_protocol }}://{{ template "cortex.fullname" . }}-distributor.{{ $rootDomain }}$request_uri;
         }
 
         location = /api/prom/push {
-          proxy_pass      http://{{ template "cortex.fullname" . }}-distributor.{{ $rootDomain }}$request_uri;
+          proxy_pass      {{ .Values.nginx.config.upstream_protocol }}://{{ template "cortex.fullname" . }}-distributor.{{ $rootDomain }}$request_uri;
         }
 
         ## New Remote write API. Ref: https://cortexmetrics.io/docs/api/#remote-write
         location = /api/v1/push {
-          proxy_pass      http://{{ template "cortex.fullname" . }}-distributor.{{ $rootDomain }}$request_uri;
+          proxy_pass      {{ .Values.nginx.config.upstream_protocol }}://{{ template "cortex.fullname" . }}-distributor.{{ $rootDomain }}$request_uri;
         }
 
         {{- end }}
@@ -103,19 +103,19 @@ data:
 
         # Alertmanager Config
         location ~ /api/prom/alertmanager/.* {
-          proxy_pass      http://{{ template "cortex.fullname" . }}-alertmanager.{{ $rootDomain }}$request_uri;
+          proxy_pass      {{ .Values.nginx.config.upstream_protocol }}://{{ template "cortex.fullname" . }}-alertmanager.{{ $rootDomain }}$request_uri;
         }
 
         location ~ /api/v1/alerts {
-          proxy_pass      http://{{ template "cortex.fullname" . }}-alertmanager.{{ $rootDomain }}$request_uri;
+          proxy_pass      {{ .Values.nginx.config.upstream_protocol }}://{{ template "cortex.fullname" . }}-alertmanager.{{ $rootDomain }}$request_uri;
         }
 
         location ~ /multitenant_alertmanager/status {
-          proxy_pass      http://{{ template "cortex.fullname" . }}-alertmanager.{{ $rootDomain }}$request_uri;
+          proxy_pass      {{ .Values.nginx.config.upstream_protocol }}://{{ template "cortex.fullname" . }}-alertmanager.{{ $rootDomain }}$request_uri;
         }
 
         location = /api/prom/api/v1/alerts {
-          proxy_pass      http://{{ template "cortex.fullname" . }}-alertmanager.{{ $rootDomain }}/api/v1/alerts;
+          proxy_pass      {{ .Values.nginx.config.upstream_protocol }}://{{ template "cortex.fullname" . }}-alertmanager.{{ $rootDomain }}/api/v1/alerts;
         }
 
         {{- end }}
@@ -124,15 +124,15 @@ data:
 
         # Ruler Config
         location ~ /api/v1/rules {
-          proxy_pass      http://{{ template "cortex.fullname" . }}-ruler.{{ $rootDomain }}$request_uri;
+          proxy_pass      {{ .Values.nginx.config.upstream_protocol }}://{{ template "cortex.fullname" . }}-ruler.{{ $rootDomain }}$request_uri;
         }
 
         location ~ /ruler/ring {
-          proxy_pass      http://{{ template "cortex.fullname" . }}-ruler.{{ $rootDomain }}$request_uri;
+          proxy_pass      {{ .Values.nginx.config.upstream_protocol }}://{{ template "cortex.fullname" . }}-ruler.{{ $rootDomain }}$request_uri;
         }
 
         location ~ /api/prom/rules {
-          proxy_pass      http://{{ template "cortex.fullname" . }}-ruler.{{ $rootDomain }}$request_uri;
+          proxy_pass      {{ .Values.nginx.config.upstream_protocol }}://{{ template "cortex.fullname" . }}-ruler.{{ $rootDomain }}$request_uri;
         }
 
         {{- end }}
@@ -141,16 +141,16 @@ data:
 
         # Query Config
         location ~ /api/prom/.* {
-          proxy_pass      http://{{ template "cortex.fullname" . }}-query-frontend.{{ $rootDomain }}$request_uri;
+          proxy_pass      {{ .Values.nginx.config.upstream_protocol }}://{{ template "cortex.fullname" . }}-query-frontend.{{ $rootDomain }}$request_uri;
         }
 
         ## New Query frontend APIs as per https://cortexmetrics.io/docs/api/#querier--query-frontend
         location ~ ^{{.Values.config.api.prometheus_http_prefix}}/api/v1/(read|metadata|labels|series|query_range|query) {
-          proxy_pass      http://{{ template "cortex.fullname" . }}-query-frontend.{{ $rootDomain }}$request_uri;
+          proxy_pass      {{ .Values.nginx.config.upstream_protocol }}://{{ template "cortex.fullname" . }}-query-frontend.{{ $rootDomain }}$request_uri;
         }
 
         location ~ {{.Values.config.api.prometheus_http_prefix}}/api/v1/label/.* {
-          proxy_pass      http://{{ template "cortex.fullname" . }}-query-frontend.{{ $rootDomain }}$request_uri;
+          proxy_pass      {{ .Values.nginx.config.upstream_protocol }}://{{ template "cortex.fullname" . }}-query-frontend.{{ $rootDomain }}$request_uri;
         }
 
         {{- end }}
@@ -160,7 +160,7 @@ data:
         {{- range $org := compact .Values.nginx.config.auth_orgs | uniq }}
         location = /api/v1/push/{{ $org }} {
           proxy_set_header      X-Scope-OrgID {{ $org }};
-          proxy_pass      http://{{ template "cortex.fullname" $ }}-distributor.{{ $rootDomain }}/api/v1/push;
+          proxy_pass      {{ .Values.nginx.config.upstream_protocol }}://{{ template "cortex.fullname" $ }}-distributor.{{ $rootDomain }}/api/v1/push;
         }
         {{- end }}
         {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -1196,6 +1196,8 @@ nginx:
     mainSnippet: ""
     # -- arbitrary snippet to inject in the server { } section of the nginx config
     serverSnippet: ""
+    # -- protocol for the communication with the upstream
+    upstream_protocol: http
     setHeaders: {}
     # -- Optional list of [auth tenants](https://cortexmetrics.io/docs/guides/auth/) to set in the nginx config
     auth_orgs: []


### PR DESCRIPTION
**What this PR does**:
Add the possibility to configure the protocol for the upstream URLs in the nginx configuration.

**Which issue(s) this PR fixes**:
When preparing to upgrade to TLS communication we ran into the problem that the nginx upstream URLs are hard-coded to http.

**Checklist**
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`