### PR TITLE
fix: upstream_protocol reference in auth_orgs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## master / unreleased
 
+* [BUGFIX] fix: upstream_protocol reference in auth_orgs #509
 * [ENHANCEMENT] Add `nginx.config.upstream_protocol` field to configure the upstream protocol in the nginx configuration #506
 
 ## 2.4.0 / 2024-07-18

--- a/templates/nginx/nginx-config.yaml
+++ b/templates/nginx/nginx-config.yaml
@@ -160,7 +160,7 @@ data:
         {{- range $org := compact .Values.nginx.config.auth_orgs | uniq }}
         location = /api/v1/push/{{ $org }} {
           proxy_set_header      X-Scope-OrgID {{ $org }};
-          proxy_pass      {{ .Values.nginx.config.upstream_protocol }}://{{ template "cortex.fullname" $ }}-distributor.{{ $rootDomain }}/api/v1/push;
+          proxy_pass      {{ $.Values.nginx.config.upstream_protocol }}://{{ template "cortex.fullname" $ }}-distributor.{{ $rootDomain }}/api/v1/push;
         }
         {{- end }}
         {{- end }}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
3. Please do not edit/bump the Chart.yaml "version" field
-->

**What this PR does**:
`auth_orgs` was broken because inside the `range` the upstream protocol feature tried to read the variable from local scope when it only exists in global scope.

Demo:
```
% helm template . --set config.auth_enabled=true --set 'nginx.config.auth_orgs={org_name}' > /dev/null
Error: template: cortex/templates/nginx/nginx-dep.yaml:28:28: executing "cortex/templates/nginx/nginx-dep.yaml" at <include (print $.Template.BasePath "/nginx/nginx-config.yaml") .>: error calling include: template: cortex/templates/nginx/nginx-config.yaml:163:36: executing "cortex/templates/nginx/nginx-config.yaml" at <.Values.nginx.config.upstream_protocol>: can't evaluate field Values in type interface {}

Use --debug flag to render out invalid YAML
```

**Which issue(s) this PR fixes**:
Fixes bug in #506

**Checklist**
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`