### PR TITLE
Set align_queries_with_step to false as default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## master / unreleased
 
+* [CHANGE] Updated default `align_queries_with_step` to **false** to match documentation #513
 * [ENHANCEMENT] Add `nginx.config.upstream_protocol` field to configure the upstream protocol in the nginx configuration #506
 * [BUGFIX] fix: upstream_protocol reference in auth_orgs #509
 * [DEPENDENCY] Update quay.io/cortexproject/cortex Docker tag to v1.18.1 #510

--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ Kubernetes: `^1.19.0-0`
 | config.&ZeroWidthSpace;memberlist.&ZeroWidthSpace;join_members | list | `["{{ include \"cortex.fullname\" $ }}-memberlist"]` | the service name of the memberlist if using memberlist discovery |
 | config.&ZeroWidthSpace;querier.&ZeroWidthSpace;active_query_tracker_dir | string | `"/data/active-query-tracker"` |  |
 | config.&ZeroWidthSpace;querier.&ZeroWidthSpace;store_gateway_addresses | string | automatic | Comma separated list of store-gateway addresses in DNS Service Discovery format. This option should is set automatically when using the blocks storage and the store-gateway sharding is disabled (when enabled, the store-gateway instances form a ring and addresses are picked from the ring). |
-| config.&ZeroWidthSpace;query_range.&ZeroWidthSpace;align_queries_with_step | bool | `true` |  |
+| config.&ZeroWidthSpace;query_range.&ZeroWidthSpace;align_queries_with_step | bool | `false` |  |
 | config.&ZeroWidthSpace;query_range.&ZeroWidthSpace;cache_results | bool | `true` |  |
 | config.&ZeroWidthSpace;query_range.&ZeroWidthSpace;results_cache.&ZeroWidthSpace;cache.&ZeroWidthSpace;memcached.&ZeroWidthSpace;expiration | string | `"1h"` |  |
 | config.&ZeroWidthSpace;query_range.&ZeroWidthSpace;results_cache.&ZeroWidthSpace;cache.&ZeroWidthSpace;memcached_client.&ZeroWidthSpace;timeout | string | `"1s"` |  |

--- a/values.yaml
+++ b/values.yaml
@@ -111,7 +111,7 @@ config:
       {{- end }}
   query_range:
     split_queries_by_interval: 24h
-    align_queries_with_step: true
+    align_queries_with_step: false
     cache_results: true
     results_cache:
       cache:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
3. Please do not edit/bump the Chart.yaml "version" field
-->

**What this PR does**:
Set align_queries_with_step to false as default, since the 'querier.align-querier-with-step' is false in the [official Cortex docs](https://cortexmetrics.io/docs/configuration/configuration-file/#query_range_config:~:text=%5Balign_queries_with_step%3A%20%3Cboolean%3E%20%7C%20default%20%3D%20false%5D) and [Cortex implementation](https://github.com/cortexproject/cortex/blob/5dd107290f615239d3538ecfdfd63781fc476c31/pkg/querier/tripperware/queryrange/query_range_middlewares.go#L53).

**Which issue(s) this PR fixes**:
Fixes #514

**Checklist**
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`, `[DEPENDENCY]`
