### PR TITLE
Bump github actions dependencies

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -15,19 +15,17 @@ jobs:
       - name: Set up Helm
         uses: azure/setup-helm@v3
         with:
-          version: v3.4.1
+          version: v3.12.1
 
       # Python is required because `ct lint` runs Yamale (https://github.com/23andMe/Yamale) and
       # yamllint (https://github.com/adrienverge/yamllint) which require Python
-      - name: Set up Python
-        uses: actions/setup-python@v4
+      - uses: actions/setup-python@v4
         with:
-          python-version: 3.7
+          python-version: '3.10'
+          check-latest: true
 
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.3.1
-        with:
-          version: v3.4.0
+        uses: helm/chart-testing-action@v2.6.1
 
       - name: Run chart-testing (lint)
         run: ct lint --config ct.yaml
@@ -38,7 +36,7 @@ jobs:
           git diff --exit-code -- README.md
 
       - name: Create kind cluster
-        uses: helm/kind-action@v1.5.0
+        uses: helm/kind-action@v1.8.0
 
       - name: Run chart-testing (install)
         run: |


### PR DESCRIPTION
**What this PR does**:

Bumps github actions so the pipeline can run again. py 3.7 is now deprecated with ubuntu 20.04.

All dependencies were bumped to the version given as the example from the https://github.com/helm/chart-testing-action/tree/v2.6.1?tab=readme-ov-file#example-workflow action.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`, `[DEPENDENCY]`
