### PR TITLE
Add ability to configure StatefulSet PVC retention policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * [CHANGE] Updated default `align_queries_with_step` to **false** to match documentation #513
 * [ENHANCEMENT] Add `nginx.config.upstream_protocol` field to configure the upstream protocol in the nginx configuration #506
+* [ENHANCEMENT] Add ability to set `persistentVolumeClaimRetentionPolicy` on alertmanager, ingester, compactor, and store-gateway StatefulSets #517
 * [BUGFIX] fix: upstream_protocol reference in auth_orgs #509
 * [DEPENDENCY] Update quay.io/cortexproject/cortex Docker tag to v1.18.1 #510
 

--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ Kubernetes: `^1.19.0-0`
 | alertmanager.&ZeroWidthSpace;persistentVolume.&ZeroWidthSpace;accessModes | list | `["ReadWriteOnce"]` | Alertmanager data Persistent Volume access modes Must match those of existing PV or dynamic provisioner Ref: http://kubernetes.io/docs/user-guide/persistent-volumes/ |
 | alertmanager.&ZeroWidthSpace;persistentVolume.&ZeroWidthSpace;annotations | object | `{}` | Alertmanager data Persistent Volume Claim annotations |
 | alertmanager.&ZeroWidthSpace;persistentVolume.&ZeroWidthSpace;enabled | bool | `true` | If true and alertmanager.statefulSet.enabled is true, Alertmanager will create/use a Persistent Volume Claim If false, use emptyDir |
+| alertmanager.&ZeroWidthSpace;persistentVolume.&ZeroWidthSpace;retentionPolicy | object | `{}` | StatefulSetAutoDeletePVC feature https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#persistentvolumeclaim-retention |
 | alertmanager.&ZeroWidthSpace;persistentVolume.&ZeroWidthSpace;size | string | `"2Gi"` | Alertmanager data Persistent Volume size |
 | alertmanager.&ZeroWidthSpace;persistentVolume.&ZeroWidthSpace;storageClass | string | `nil` | Alertmanager data Persistent Volume Storage Class If defined, storageClassName: <storageClass> If set to "-", storageClassName: "", which disables dynamic provisioning If undefined (the default) or set to null, no storageClassName spec is set, choosing the default provisioner. |
 | alertmanager.&ZeroWidthSpace;persistentVolume.&ZeroWidthSpace;subPath | string | `""` | Subdirectory of Alertmanager data Persistent Volume to mount Useful if the volume's root directory is not empty |
@@ -184,6 +185,7 @@ Kubernetes: `^1.19.0-0`
 | compactor.&ZeroWidthSpace;persistentVolume.&ZeroWidthSpace;accessModes | list | `["ReadWriteOnce"]` | compactor data Persistent Volume access modes Must match those of existing PV or dynamic provisioner Ref: http://kubernetes.io/docs/user-guide/persistent-volumes/ |
 | compactor.&ZeroWidthSpace;persistentVolume.&ZeroWidthSpace;annotations | object | `{}` | compactor data Persistent Volume Claim annotations |
 | compactor.&ZeroWidthSpace;persistentVolume.&ZeroWidthSpace;enabled | bool | `true` | If true compactor will create/use a Persistent Volume Claim If false, use emptyDir |
+| compactor.&ZeroWidthSpace;persistentVolume.&ZeroWidthSpace;retentionPolicy | object | `{}` | StatefulSetAutoDeletePVC feature https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#persistentvolumeclaim-retention |
 | compactor.&ZeroWidthSpace;persistentVolume.&ZeroWidthSpace;size | string | `"2Gi"` |  |
 | compactor.&ZeroWidthSpace;persistentVolume.&ZeroWidthSpace;storageClass | string | `nil` | compactor data Persistent Volume Storage Class If defined, storageClassName: <storageClass> If set to "-", storageClassName: "", which disables dynamic provisioning If undefined (the default) or set to null, no storageClassName spec is set, choosing the default provisioner. |
 | compactor.&ZeroWidthSpace;persistentVolume.&ZeroWidthSpace;subPath | string | `""` | Subdirectory of compactor data Persistent Volume to mount Useful if the volume's root directory is not empty |
@@ -346,6 +348,7 @@ Kubernetes: `^1.19.0-0`
 | ingester.&ZeroWidthSpace;persistentVolume.&ZeroWidthSpace;accessModes | list | `["ReadWriteOnce"]` | Ingester data Persistent Volume access modes Must match those of existing PV or dynamic provisioner Ref: http://kubernetes.io/docs/user-guide/persistent-volumes/ |
 | ingester.&ZeroWidthSpace;persistentVolume.&ZeroWidthSpace;annotations | object | `{}` | Ingester data Persistent Volume Claim annotations |
 | ingester.&ZeroWidthSpace;persistentVolume.&ZeroWidthSpace;enabled | bool | `true` | If true and ingester.statefulSet.enabled is true, Ingester will create/use a Persistent Volume Claim If false, use emptyDir |
+| ingester.&ZeroWidthSpace;persistentVolume.&ZeroWidthSpace;retentionPolicy | object | `{}` | StatefulSetAutoDeletePVC feature https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#persistentvolumeclaim-retention |
 | ingester.&ZeroWidthSpace;persistentVolume.&ZeroWidthSpace;size | string | `"2Gi"` | Ingester data Persistent Volume size |
 | ingester.&ZeroWidthSpace;persistentVolume.&ZeroWidthSpace;storageClass | string | `nil` | Ingester data Persistent Volume Storage Class If defined, storageClassName: <storageClass> If set to "-", storageClassName: "", which disables dynamic provisioning If undefined (the default) or set to null, no storageClassName spec is set, choosing the default provisioner. |
 | ingester.&ZeroWidthSpace;persistentVolume.&ZeroWidthSpace;subPath | string | `""` | Subdirectory of Ingester data Persistent Volume to mount Useful if the volume's root directory is not empty |
@@ -815,6 +818,7 @@ Kubernetes: `^1.19.0-0`
 | store_gateway.&ZeroWidthSpace;persistentVolume.&ZeroWidthSpace;accessModes | list | `["ReadWriteOnce"]` | Store-gateway data Persistent Volume access modes Must match those of existing PV or dynamic provisioner Ref: http://kubernetes.io/docs/user-guide/persistent-volumes/ |
 | store_gateway.&ZeroWidthSpace;persistentVolume.&ZeroWidthSpace;annotations | object | `{}` | Store-gateway data Persistent Volume Claim annotations |
 | store_gateway.&ZeroWidthSpace;persistentVolume.&ZeroWidthSpace;enabled | bool | `true` | If true Store-gateway will create/use a Persistent Volume Claim If false, use emptyDir |
+| store_gateway.&ZeroWidthSpace;persistentVolume.&ZeroWidthSpace;retentionPolicy | object | `{}` | StatefulSetAutoDeletePVC feature https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#persistentvolumeclaim-retention |
 | store_gateway.&ZeroWidthSpace;persistentVolume.&ZeroWidthSpace;size | string | `"2Gi"` | Store-gateway data Persistent Volume size |
 | store_gateway.&ZeroWidthSpace;persistentVolume.&ZeroWidthSpace;storageClass | string | `nil` | Store-gateway data Persistent Volume Storage Class If defined, storageClassName: <storageClass> If set to "-", storageClassName: "", which disables dynamic provisioning If undefined (the default) or set to null, no storageClassName spec is set, choosing the default provisioner. |
 | store_gateway.&ZeroWidthSpace;persistentVolume.&ZeroWidthSpace;subPath | string | `""` | Subdirectory of Store-gateway data Persistent Volume to mount Useful if the volume's root directory is not empty |

--- a/templates/alertmanager/alertmanager-statefulset.yaml
+++ b/templates/alertmanager/alertmanager-statefulset.yaml
@@ -21,6 +21,12 @@ spec:
     {{- toYaml .Values.alertmanager.statefulStrategy | nindent 4 }}
   serviceName: {{ template "cortex.fullname" . }}-alertmanager-headless
   {{- if .Values.alertmanager.persistentVolume.enabled }}
+  {{- if semverCompare ">=1.23-0" .Capabilities.KubeVersion.Version }}
+  {{- with .Values.alertmanager.persistentVolume.retentionPolicy }}
+  persistentVolumeClaimRetentionPolicy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- end }}
   volumeClaimTemplates:
     - metadata:
         name: storage

--- a/templates/compactor/compactor-statefulset.yaml
+++ b/templates/compactor/compactor-statefulset.yaml
@@ -18,6 +18,12 @@ spec:
     {{- toYaml .Values.compactor.strategy | nindent 4 }}
   serviceName: {{ template "cortex.fullname" . }}-compactor
   {{- if .Values.compactor.persistentVolume.enabled }}
+  {{- if semverCompare ">=1.23-0" .Capabilities.KubeVersion.Version }}
+  {{- with .Values.compactor.persistentVolume.retentionPolicy }}
+  persistentVolumeClaimRetentionPolicy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- end }}
   volumeClaimTemplates:
     - metadata:
         name: storage

--- a/templates/ingester/ingester-statefulset.yaml
+++ b/templates/ingester/ingester-statefulset.yaml
@@ -21,6 +21,12 @@ spec:
   podManagementPolicy: "{{ .Values.ingester.statefulSet.podManagementPolicy }}"
   serviceName: {{ template "cortex.fullname" . }}-ingester-headless
   {{- if .Values.ingester.persistentVolume.enabled }}
+  {{- if semverCompare ">=1.23-0" .Capabilities.KubeVersion.Version }}
+  {{- with .Values.ingester.persistentVolume.retentionPolicy }}
+  persistentVolumeClaimRetentionPolicy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- end }}
   volumeClaimTemplates:
     - metadata:
         name: storage

--- a/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/templates/store-gateway/store-gateway-statefulset.yaml
@@ -21,6 +21,12 @@ spec:
   podManagementPolicy: {{ .Values.store_gateway.podManagementPolicy | quote }}
   serviceName: {{ template "cortex.fullname" . }}-store-gateway-headless
   {{- if .Values.store_gateway.persistentVolume.enabled }}
+  {{- if semverCompare ">=1.23-0" .Capabilities.KubeVersion.Version }}
+  {{- with .Values.store_gateway.persistentVolume.retentionPolicy }}
+  persistentVolumeClaimRetentionPolicy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- end }}
   volumeClaimTemplates:
     - metadata:
         name: storage

--- a/values.yaml
+++ b/values.yaml
@@ -217,6 +217,12 @@ alertmanager:
     # set, choosing the default provisioner.
     storageClass: null
 
+    # -- StatefulSetAutoDeletePVC feature
+    # https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#persistentvolumeclaim-retention
+    retentionPolicy: {}
+    # whenDeleted: Retain
+    # whenScaled: Retain
+
   startupProbe:
     httpGet:
       path: /ready
@@ -542,6 +548,12 @@ ingester:
     # If undefined (the default) or set to null, no storageClassName spec is
     # set, choosing the default provisioner.
     storageClass: null
+
+    # -- StatefulSetAutoDeletePVC feature
+    # https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#persistentvolumeclaim-retention
+    retentionPolicy: {}
+    # whenDeleted: Retain
+    # whenScaled: Retain
 
   # -- Startup/liveness probes for ingesters are not recommended.
   #  Ref: https://cortexmetrics.io/docs/guides/running-cortex-on-kubernetes/#take-extra-care-with-ingesters
@@ -1404,6 +1416,12 @@ store_gateway:
     # set, choosing the default provisioner.
     storageClass: null
 
+    # -- StatefulSetAutoDeletePVC feature
+    # https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#persistentvolumeclaim-retention
+    retentionPolicy: {}
+    # whenDeleted: Retain
+    # whenScaled: Retain
+
   startupProbe:
     failureThreshold: 60
     initialDelaySeconds: 120
@@ -1519,6 +1537,12 @@ compactor:
     # If undefined (the default) or set to null, no storageClassName spec is
     # set, choosing the default provisioner.
     storageClass: null
+
+    # -- StatefulSetAutoDeletePVC feature
+    # https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#persistentvolumeclaim-retention
+    retentionPolicy: {}
+    # whenDeleted: Retain
+    # whenScaled: Retain
 
   startupProbe:
     failureThreshold: 60


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
3. Please do not edit/bump the Chart.yaml "version" field
-->

**What this PR does**:
Adds values allowing users to configure the `persistentVolumeClaimRetentionPolicy` on StatefulSets deployed by the chart.

**Which issue(s) this PR fixes**:
Fixes #516

**Checklist**
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`, `[DEPENDENCY]`
