### PR TITLE
feat(cortex-nginx): optional override push endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## master / unreleased
 
 * [DEPENDENCY] Update quay.io/cortexproject/cortex Docker tag to v1.19.0 #521
+* [ENHANCEMENT] Add `nginx.config.override_push_endpoint` field to override push endpoint in the nginx configuration #522
 
 ## 2.5.0 / 2025-01-17
 

--- a/README.md
+++ b/README.md
@@ -440,6 +440,7 @@ Kubernetes: `^1.19.0-0`
 | nginx.&ZeroWidthSpace;config.&ZeroWidthSpace;dnsTTL | string | `"15s"` | Including the valid parameter to the `resolver` directive to re-resolve names every `dnsTTL` seconds/minutes |
 | nginx.&ZeroWidthSpace;config.&ZeroWidthSpace;httpSnippet | string | `""` | arbitrary snippet to inject in the http { } section of the nginx config |
 | nginx.&ZeroWidthSpace;config.&ZeroWidthSpace;mainSnippet | string | `""` | arbitrary snippet to inject in the top section of the nginx config |
+| nginx.&ZeroWidthSpace;config.&ZeroWidthSpace;override_push_endpoint | string | `""` |  |
 | nginx.&ZeroWidthSpace;config.&ZeroWidthSpace;serverSnippet | string | `""` | arbitrary snippet to inject in the server { } section of the nginx config |
 | nginx.&ZeroWidthSpace;config.&ZeroWidthSpace;setHeaders | object | `{}` |  |
 | nginx.&ZeroWidthSpace;config.&ZeroWidthSpace;upstream_protocol | string | `"http"` | protocol for the communication with the upstream |

--- a/templates/nginx/nginx-config.yaml
+++ b/templates/nginx/nginx-config.yaml
@@ -87,25 +87,16 @@ data:
         location = /all_user_stats {
           proxy_pass      {{ .Values.nginx.config.upstream_protocol }}://{{ template "cortex.fullname" . }}-distributor.{{ $rootDomain }}$request_uri;
         }
-        {{ if .Values.nginx.config.override_push_endpoint }}
+        {{- $push_endpoint := .Values.nginx.config.override_push_endpoint | default (printf "%s://%s-distributor.%s" .Values.nginx.config.upstream_protocol (include "cortex.fullname" .) $rootDomain) }}
+        # Push API endpoints
         location = /api/prom/push {
-          proxy_pass      {{ .Values.nginx.config.upstream_protocol }}://{{ .Values.nginx.config.override_push_endpoint }}$request_uri;
+          proxy_pass      {{ $push_endpoint }}$request_uri;
         }
 
         ## New Remote write API. Ref: https://cortexmetrics.io/docs/api/#remote-write
         location = /api/v1/push {
-          proxy_pass      {{ .Values.nginx.config.upstream_protocol }}://{{ .Values.nginx.config.override_push_endpoint }}$request_uri;
+          proxy_pass      {{ $push_endpoint }}$request_uri;
         }
-        {{- else }}
-        location = /api/prom/push {
-          proxy_pass      {{ .Values.nginx.config.upstream_protocol }}://{{ template "cortex.fullname" . }}-distributor.{{ $rootDomain }}$request_uri;
-        }
-
-        ## New Remote write API. Ref: https://cortexmetrics.io/docs/api/#remote-write
-        location = /api/v1/push {
-          proxy_pass      {{ .Values.nginx.config.upstream_protocol }}://{{ template "cortex.fullname" . }}-distributor.{{ $rootDomain }}$request_uri;
-        }
-        {{- end }}
         {{- end }}
 
         {{- if .Values.alertmanager.enabled }}

--- a/templates/nginx/nginx-config.yaml
+++ b/templates/nginx/nginx-config.yaml
@@ -87,7 +87,16 @@ data:
         location = /all_user_stats {
           proxy_pass      {{ .Values.nginx.config.upstream_protocol }}://{{ template "cortex.fullname" . }}-distributor.{{ $rootDomain }}$request_uri;
         }
+        {{ if .Values.nginx.config.override_push_endpoint }}
+        location = /api/prom/push {
+          proxy_pass      {{ .Values.nginx.config.upstream_protocol }}://{{ .Values.nginx.config.override_push_endpoint }}$request_uri;
+        }
 
+        ## New Remote write API. Ref: https://cortexmetrics.io/docs/api/#remote-write
+        location = /api/v1/push {
+          proxy_pass      {{ .Values.nginx.config.upstream_protocol }}://{{ .Values.nginx.config.override_push_endpoint }}$request_uri;
+        }
+        {{- else }}
         location = /api/prom/push {
           proxy_pass      {{ .Values.nginx.config.upstream_protocol }}://{{ template "cortex.fullname" . }}-distributor.{{ $rootDomain }}$request_uri;
         }
@@ -96,7 +105,7 @@ data:
         location = /api/v1/push {
           proxy_pass      {{ .Values.nginx.config.upstream_protocol }}://{{ template "cortex.fullname" . }}-distributor.{{ $rootDomain }}$request_uri;
         }
-
+        {{- end }}
         {{- end }}
 
         {{- if .Values.alertmanager.enabled }}

--- a/values.yaml
+++ b/values.yaml
@@ -1239,6 +1239,10 @@ nginx:
     dnsTTL: "15s"
     # -- Enables all access logs from nginx, otherwise ignores 2XX and 3XX status codes
     verboseLogging: true
+
+    ## -- Optional: Override the URL for push endpoints (/api/prom/push and /api/v1/push)
+    ## If not specified, the default URL will be used, corresponding to the distributor service URL
+    override_push_endpoint: ""
   image:
     repository: nginx
     tag: 1.23


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
3. Please do not edit/bump the Chart.yaml "version" field
-->

**What this PR does**:

Provide an option to override the push endpoint. For the use cases of mirroring or re-routing the requests before hitting the distributors.

**Which issue(s) this PR fixes**:

Partially provide an option for #520 

**Checklist**
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`, `[DEPENDENCY]`

**Additional notes**

Testing:

```
helm template . | grep /push -A2                                                         
        location = /api/prom/push {
          proxy_pass      http://release-name-cortex-distributor.default.svc.cluster.local:8080$request_uri;
        }
--
        location = /api/v1/push {
          proxy_pass      http://release-name-cortex-distributor.default.svc.cluster.local:8080$request_uri;
        }
========
helm template . --set nginx.config.override_push_endpoint=https://example.com:8080 | grep /push -A2
        location = /api/prom/push {
          proxy_pass      https://example.com:8080$request_uri;
        }
--
        location = /api/v1/push {
          proxy_pass      https://example.com:8080$request_uri;
        }
```

We are running this setup with the envoy proxy for mirroring the requests to a secondary Cortex. With the change we can effectively override the push endpoint to the envoy first, then do the mirror technique.

This was the working Envoy configuration (v3) where cortex_primary is our distributor service and cortex_secondary is an ingress to the secondary cluster's distributors.

```
admin:
  access_log_path: /dev/null
  address:
    socket_address:
      address: 0.0.0.0
      port_value: 9901
static_resources:
  clusters:
  - connect_timeout: 1s
    dns_refresh_rate: 5s
    load_assignment:
      cluster_name: cortex_primary
      endpoints:
        - lb_endpoints:
            - endpoint:
                address:
                  socket_address:
                    address: {{ .Values.primary.address }}
                    port_value: {{ .Values.primary.port }}
    name: cortex_primary
    type: STRICT_DNS
  - connect_timeout: 1s
    dns_refresh_rate: 5s
    load_assignment:
      cluster_name: cortex_secondary
      endpoints:
        - lb_endpoints:
            - endpoint:
                address:
                  socket_address:
                    address: {{ .Values.secondary.address }}
                    port_value: {{ .Values.secondary.port }}
    name: cortex_secondary
    type: STRICT_DNS
  listeners:
  - address:
      socket_address:
        address: 0.0.0.0
        port_value: 8080
    filter_chains:
      - filters:
        - name: envoy.filters.network.http_connection_manager
          typed_config:
            "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
            http_filters:
            - name: envoy.filters.http.router
              typed_config:
                "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
            route_config:
              name: all_routes
              virtual_hosts:
              - domains:
                - '*'
                name: all_hosts
                routes:
                - match:
                    prefix: "/"
                  route:
                    cluster: cortex_primary
                    request_mirror_policies:
                    - cluster: cortex_secondary
                    timeout: 15s
            stat_prefix: cortex_ingress
    name: cortex_listener
```

