### PR TITLE
Remove startup probe from compactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master / unreleased
 
+* [CHANGE] Remove startup probes from compactors from default values. It's not recommended in general
+
 ## 2.6.0 / 2025-05-07
 
 * [DEPENDENCY] Update Helm release memcached to v6.14.0 #528

--- a/values.yaml
+++ b/values.yaml
@@ -1,4 +1,3 @@
-image:
   repository: quay.io/cortexproject/cortex
   # -- Allows you to override the cortex version in this chart. Use at your own risk.
   tag: ""
@@ -1548,14 +1547,7 @@ compactor:
     # whenDeleted: Retain
     # whenScaled: Retain
 
-  startupProbe:
-    failureThreshold: 60
-    initialDelaySeconds: 120
-    periodSeconds: 30
-    httpGet:
-      path: /ready
-      port: http-metrics
-      scheme: HTTP
+  startupProbe: {}
   livenessProbe: {}
   readinessProbe:
     httpGet:

--- a/values.yaml
+++ b/values.yaml
@@ -1,3 +1,4 @@
+image:
   repository: quay.io/cortexproject/cortex
   # -- Allows you to override the cortex version in this chart. Use at your own risk.
   tag: ""


### PR DESCRIPTION
In some circumstances the compactor might take a long time to start and that is not really a bug. For example when there is a high number of partial blocks to read.

**What this PR does**:  Remove startup probe from compactor

**Which issue(s) this PR fixes**: it works towards #473

**Checklist**
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`, `[DEPENDENCY]`
