### PR TITLE
Change defaults: Increase pod disruption budget for some stateless components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## master / unreleased
 
+* [CHANGE] Change default config: distributors, rulers, queriers, query-frontend, nginx and compactors can be disrupted until 30%
 * [CHANGE] Remove startup probes from compactors from default values. It's not recommended in general #542
 * [CHANGE] Use default value for num_tokens in ingester configuration #544
 

--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ Kubernetes: `^1.19.0-0`
 | compactor.&ZeroWidthSpace;persistentVolume.&ZeroWidthSpace;storageClass | string | `nil` | compactor data Persistent Volume Storage Class If defined, storageClassName: <storageClass> If set to "-", storageClassName: "", which disables dynamic provisioning If undefined (the default) or set to null, no storageClassName spec is set, choosing the default provisioner. |
 | compactor.&ZeroWidthSpace;persistentVolume.&ZeroWidthSpace;subPath | string | `""` | Subdirectory of compactor data Persistent Volume to mount Useful if the volume's root directory is not empty |
 | compactor.&ZeroWidthSpace;podAnnotations | object | `{"prometheus.io/port":"8080","prometheus.io/scrape":"true"}` | Pod Annotations |
-| compactor.&ZeroWidthSpace;podDisruptionBudget.&ZeroWidthSpace;maxUnavailable | int | `1` |  |
+| compactor.&ZeroWidthSpace;podDisruptionBudget.&ZeroWidthSpace;maxUnavailable | string | `"30%"` |  |
 | compactor.&ZeroWidthSpace;podLabels | object | `{}` | Pod Labels |
 | compactor.&ZeroWidthSpace;readinessProbe.&ZeroWidthSpace;httpGet.&ZeroWidthSpace;path | string | `"/ready"` |  |
 | compactor.&ZeroWidthSpace;readinessProbe.&ZeroWidthSpace;httpGet.&ZeroWidthSpace;port | string | `"http-metrics"` |  |
@@ -281,7 +281,7 @@ Kubernetes: `^1.19.0-0`
 | distributor.&ZeroWidthSpace;nodeSelector | object | `{}` |  |
 | distributor.&ZeroWidthSpace;persistentVolume.&ZeroWidthSpace;subPath | string | `nil` |  |
 | distributor.&ZeroWidthSpace;podAnnotations | object | `{"prometheus.io/port":"8080","prometheus.io/scrape":"true"}` | Pod Annotations |
-| distributor.&ZeroWidthSpace;podDisruptionBudget.&ZeroWidthSpace;maxUnavailable | int | `1` |  |
+| distributor.&ZeroWidthSpace;podDisruptionBudget.&ZeroWidthSpace;maxUnavailable | string | `"30%"` |  |
 | distributor.&ZeroWidthSpace;podLabels | object | `{}` | Pod Labels |
 | distributor.&ZeroWidthSpace;readinessProbe.&ZeroWidthSpace;httpGet.&ZeroWidthSpace;path | string | `"/ready"` |  |
 | distributor.&ZeroWidthSpace;readinessProbe.&ZeroWidthSpace;httpGet.&ZeroWidthSpace;port | string | `"http-metrics"` |  |
@@ -458,7 +458,7 @@ Kubernetes: `^1.19.0-0`
 | nginx.&ZeroWidthSpace;nodeSelector | object | `{}` |  |
 | nginx.&ZeroWidthSpace;persistentVolume.&ZeroWidthSpace;subPath | string | `nil` |  |
 | nginx.&ZeroWidthSpace;podAnnotations | object | `{}` | Pod Annotations |
-| nginx.&ZeroWidthSpace;podDisruptionBudget.&ZeroWidthSpace;maxUnavailable | int | `1` |  |
+| nginx.&ZeroWidthSpace;podDisruptionBudget.&ZeroWidthSpace;maxUnavailable | string | `"30%"` |  |
 | nginx.&ZeroWidthSpace;podLabels | object | `{}` | Pod Labels |
 | nginx.&ZeroWidthSpace;readinessProbe.&ZeroWidthSpace;httpGet.&ZeroWidthSpace;path | string | `"/healthz"` |  |
 | nginx.&ZeroWidthSpace;readinessProbe.&ZeroWidthSpace;httpGet.&ZeroWidthSpace;port | string | `"http-metrics"` |  |
@@ -593,7 +593,7 @@ Kubernetes: `^1.19.0-0`
 | querier.&ZeroWidthSpace;nodeSelector | object | `{}` |  |
 | querier.&ZeroWidthSpace;persistentVolume.&ZeroWidthSpace;subPath | string | `nil` |  |
 | querier.&ZeroWidthSpace;podAnnotations | object | `{"prometheus.io/port":"8080","prometheus.io/scrape":"true"}` | Pod Annotations |
-| querier.&ZeroWidthSpace;podDisruptionBudget.&ZeroWidthSpace;maxUnavailable | int | `1` |  |
+| querier.&ZeroWidthSpace;podDisruptionBudget.&ZeroWidthSpace;maxUnavailable | string | `"30%"` |  |
 | querier.&ZeroWidthSpace;podLabels | object | `{}` | Pod Labels |
 | querier.&ZeroWidthSpace;readinessProbe.&ZeroWidthSpace;httpGet.&ZeroWidthSpace;path | string | `"/ready"` |  |
 | querier.&ZeroWidthSpace;readinessProbe.&ZeroWidthSpace;httpGet.&ZeroWidthSpace;port | string | `"http-metrics"` |  |
@@ -640,7 +640,7 @@ Kubernetes: `^1.19.0-0`
 | query_frontend.&ZeroWidthSpace;nodeSelector | object | `{}` |  |
 | query_frontend.&ZeroWidthSpace;persistentVolume.&ZeroWidthSpace;subPath | string | `nil` |  |
 | query_frontend.&ZeroWidthSpace;podAnnotations | object | `{"prometheus.io/port":"8080","prometheus.io/scrape":"true"}` | Pod Annotations |
-| query_frontend.&ZeroWidthSpace;podDisruptionBudget.&ZeroWidthSpace;maxUnavailable | int | `1` |  |
+| query_frontend.&ZeroWidthSpace;podDisruptionBudget.&ZeroWidthSpace;maxUnavailable | string | `"30%"` |  |
 | query_frontend.&ZeroWidthSpace;podLabels | object | `{}` | Pod Labels |
 | query_frontend.&ZeroWidthSpace;readinessProbe.&ZeroWidthSpace;httpGet.&ZeroWidthSpace;path | string | `"/ready"` |  |
 | query_frontend.&ZeroWidthSpace;readinessProbe.&ZeroWidthSpace;httpGet.&ZeroWidthSpace;port | string | `"http-metrics"` |  |
@@ -735,7 +735,7 @@ Kubernetes: `^1.19.0-0`
 | ruler.&ZeroWidthSpace;livenessProbe.&ZeroWidthSpace;httpGet.&ZeroWidthSpace;port | string | `"http-metrics"` |  |
 | ruler.&ZeroWidthSpace;nodeSelector | object | `{}` |  |
 | ruler.&ZeroWidthSpace;podAnnotations | object | `{"prometheus.io/port":"8080","prometheus.io/scrape":"true"}` | Pod Annotations |
-| ruler.&ZeroWidthSpace;podDisruptionBudget.&ZeroWidthSpace;maxUnavailable | int | `1` |  |
+| ruler.&ZeroWidthSpace;podDisruptionBudget.&ZeroWidthSpace;maxUnavailable | string | `"30%"` |  |
 | ruler.&ZeroWidthSpace;podLabels | object | `{}` | Pod Labels |
 | ruler.&ZeroWidthSpace;readinessProbe.&ZeroWidthSpace;httpGet.&ZeroWidthSpace;path | string | `"/ready"` |  |
 | ruler.&ZeroWidthSpace;readinessProbe.&ZeroWidthSpace;httpGet.&ZeroWidthSpace;port | string | `"http-metrics"` |  |

--- a/values.yaml
+++ b/values.yaml
@@ -416,7 +416,7 @@ distributor:
   tolerations: []
 
   podDisruptionBudget:
-    maxUnavailable: 1
+    maxUnavailable: 30%
 
   initContainers: []
   extraContainers: []
@@ -683,7 +683,7 @@ ruler:
   tolerations: []
 
   podDisruptionBudget:
-    maxUnavailable: 1
+    maxUnavailable: 30%
 
   initContainers: []
   extraContainers: []
@@ -832,7 +832,7 @@ querier:
   tolerations: []
 
   podDisruptionBudget:
-    maxUnavailable: 1
+    maxUnavailable: 30%
 
   initContainers: []
   extraContainers: []
@@ -925,7 +925,7 @@ query_frontend:
   tolerations: []
 
   podDisruptionBudget:
-    maxUnavailable: 1
+    maxUnavailable: 30%
 
   initContainers: []
   extraContainers: []
@@ -1305,7 +1305,7 @@ nginx:
   tolerations: []
 
   podDisruptionBudget:
-    maxUnavailable: 1
+    maxUnavailable: 30%
 
   initContainers: []
   extraContainers: []
@@ -1567,7 +1567,7 @@ compactor:
   tolerations: []
 
   podDisruptionBudget:
-    maxUnavailable: 1
+    maxUnavailable: 30%
 
   initContainers: []
   extraContainers: []


### PR DESCRIPTION

**What this PR does**: Increase pod disruption budget for some stateless components.

The "maxUnavailable: 1" is required mostly for ingesters, alertmanagers and store-gateways.  The rest don't need such a strong requirement

**Which issue(s) this PR fixes**:
This is working towards https://github.com/cortexproject/cortex-helm-chart/issues/473

**Checklist**
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`, `[DEPENDENCY]`
