### PR TITLE
Enable memcached by default and fix discovering instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,12 @@
 
 ## master / unreleased
 
+* [CHANGE] Memcacheds are now enabled by default
 * [CHANGE] Change default config: distributors, rulers, queriers, query-frontend, nginx and compactors can be disrupted until 30%
 * [CHANGE] Remove startup probes from compactors from default values. It's not recommended in general #542
 * [CHANGE] Use default value for num_tokens in ingester configuration #544
 * [DEPENDENCY] Update kiwigrid/k8s-sidecar docker tag to v1.30.5 #531
+* [BUGFIX] fix discovering memcached instances
 
 ## 2.6.0 / 2025-05-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,12 @@
 
 ## master / unreleased
 
-* [CHANGE] Memcacheds are now enabled by default
+* [CHANGE] Memcacheds are now enabled by default #551
 * [CHANGE] Change default config: distributors, rulers, queriers, query-frontend, nginx and compactors can be disrupted until 30%
 * [CHANGE] Remove startup probes from compactors from default values. It's not recommended in general #542
 * [CHANGE] Use default value for num_tokens in ingester configuration #544
 * [DEPENDENCY] Update kiwigrid/k8s-sidecar docker tag to v1.30.5 #531
-* [BUGFIX] fix discovering memcached instances
+* [BUGFIX] fix discovering memcached instances #551
 
 ## 2.6.0 / 2025-05-07
 

--- a/README.md
+++ b/README.md
@@ -383,7 +383,7 @@ Kubernetes: `^1.19.0-0`
 | memberlist.&ZeroWidthSpace;service.&ZeroWidthSpace;annotations | object | `{}` |  |
 | memberlist.&ZeroWidthSpace;service.&ZeroWidthSpace;labels | object | `{}` |  |
 | memcached-blocks-index.&ZeroWidthSpace;architecture | string | `"high-availability"` |  |
-| memcached-blocks-index.&ZeroWidthSpace;enabled | bool | `false` | Enables support for block index caching |
+| memcached-blocks-index.&ZeroWidthSpace;enabled | bool | `true` | Enables support for block index caching |
 | memcached-blocks-index.&ZeroWidthSpace;extraEnvVars[0] | object | `{"name":"MEMCACHED_CACHE_SIZE","value":"1024"}` | MEMCACHED_CACHE_SIZE is the amount of memory allocated to memcached for object storage |
 | memcached-blocks-index.&ZeroWidthSpace;extraEnvVars[1] | object | `{"name":"MEMCACHED_MAX_CONNECTIONS","value":"1024"}` | MEMCACHED_MAX_CONNECTIONS is the maximum number of simultaneous connections to the memcached service |
 | memcached-blocks-index.&ZeroWidthSpace;extraEnvVars[2] | object | `{"name":"MEMCACHED_THREADS","value":"4"}` | MEMCACHED_THREADS is the number of threads to use when processing incoming requests. By default, memcached is configured to use 4 concurrent threads. The threading improves the performance of storing and retrieving data in the cache, using a locking system to prevent different threads overwriting or updating the same values. |
@@ -391,8 +391,9 @@ Kubernetes: `^1.19.0-0`
 | memcached-blocks-index.&ZeroWidthSpace;metrics.&ZeroWidthSpace;serviceMonitor.&ZeroWidthSpace;enabled | bool | `false` |  |
 | memcached-blocks-index.&ZeroWidthSpace;replicaCount | int | `2` |  |
 | memcached-blocks-index.&ZeroWidthSpace;resources | object | `{}` |  |
+| memcached-blocks-index.&ZeroWidthSpace;service.&ZeroWidthSpace;clusterIP | string | `"None"` |  |
 | memcached-blocks-metadata.&ZeroWidthSpace;architecture | string | `"high-availability"` |  |
-| memcached-blocks-metadata.&ZeroWidthSpace;enabled | bool | `false` | Enables support for block metadata caching |
+| memcached-blocks-metadata.&ZeroWidthSpace;enabled | bool | `true` | Enables support for block metadata caching |
 | memcached-blocks-metadata.&ZeroWidthSpace;extraEnvVars[0] | object | `{"name":"MEMCACHED_CACHE_SIZE","value":"1024"}` | MEMCACHED_CACHE_SIZE is the amount of memory allocated to memcached for object storage |
 | memcached-blocks-metadata.&ZeroWidthSpace;extraEnvVars[1] | object | `{"name":"MEMCACHED_MAX_CONNECTIONS","value":"1024"}` | MEMCACHED_MAX_CONNECTIONS is the maximum number of simultaneous connections to the memcached service |
 | memcached-blocks-metadata.&ZeroWidthSpace;extraEnvVars[2] | object | `{"name":"MEMCACHED_THREADS","value":"4"}` | MEMCACHED_THREADS is the number of threads to use when processing incoming requests. By default, memcached is configured to use 4 concurrent threads. The threading improves the performance of storing and retrieving data in the cache, using a locking system to prevent different threads overwriting or updating the same values. |
@@ -400,8 +401,9 @@ Kubernetes: `^1.19.0-0`
 | memcached-blocks-metadata.&ZeroWidthSpace;metrics.&ZeroWidthSpace;serviceMonitor.&ZeroWidthSpace;enabled | bool | `false` |  |
 | memcached-blocks-metadata.&ZeroWidthSpace;replicaCount | int | `2` |  |
 | memcached-blocks-metadata.&ZeroWidthSpace;resources | object | `{}` |  |
+| memcached-blocks-metadata.&ZeroWidthSpace;service.&ZeroWidthSpace;clusterIP | string | `"None"` |  |
 | memcached-blocks.&ZeroWidthSpace;architecture | string | `"high-availability"` |  |
-| memcached-blocks.&ZeroWidthSpace;enabled | bool | `false` | Enables support for block caching |
+| memcached-blocks.&ZeroWidthSpace;enabled | bool | `true` | Enables support for block caching |
 | memcached-blocks.&ZeroWidthSpace;extraEnvVars[0] | object | `{"name":"MEMCACHED_CACHE_SIZE","value":"1024"}` | MEMCACHED_CACHE_SIZE is the amount of memory allocated to memcached for object storage |
 | memcached-blocks.&ZeroWidthSpace;extraEnvVars[1] | object | `{"name":"MEMCACHED_MAX_CONNECTIONS","value":"1024"}` | MEMCACHED_MAX_CONNECTIONS is the maximum number of simultaneous connections to the memcached service |
 | memcached-blocks.&ZeroWidthSpace;extraEnvVars[2] | object | `{"name":"MEMCACHED_THREADS","value":"4"}` | MEMCACHED_THREADS is the number of threads to use when processing incoming requests. By default, memcached is configured to use 4 concurrent threads. The threading improves the performance of storing and retrieving data in the cache, using a locking system to prevent different threads overwriting or updating the same values. |
@@ -409,8 +411,9 @@ Kubernetes: `^1.19.0-0`
 | memcached-blocks.&ZeroWidthSpace;metrics.&ZeroWidthSpace;serviceMonitor.&ZeroWidthSpace;enabled | bool | `false` |  |
 | memcached-blocks.&ZeroWidthSpace;replicaCount | int | `2` |  |
 | memcached-blocks.&ZeroWidthSpace;resources | object | `{}` |  |
+| memcached-blocks.&ZeroWidthSpace;service.&ZeroWidthSpace;clusterIP | string | `"None"` |  |
 | memcached-frontend.&ZeroWidthSpace;architecture | string | `"high-availability"` |  |
-| memcached-frontend.&ZeroWidthSpace;enabled | bool | `false` | Enables support for caching queries in the frontend |
+| memcached-frontend.&ZeroWidthSpace;enabled | bool | `true` | Enables support for caching queries in the frontend |
 | memcached-frontend.&ZeroWidthSpace;extraEnvVars[0] | object | `{"name":"MEMCACHED_CACHE_SIZE","value":"1024"}` | MEMCACHED_CACHE_SIZE is the amount of memory allocated to memcached for object storage |
 | memcached-frontend.&ZeroWidthSpace;extraEnvVars[1] | object | `{"name":"MEMCACHED_MAX_CONNECTIONS","value":"1024"}` | MEMCACHED_MAX_CONNECTIONS is the maximum number of simultaneous connections to the memcached service |
 | memcached-frontend.&ZeroWidthSpace;extraEnvVars[2] | object | `{"name":"MEMCACHED_THREADS","value":"4"}` | MEMCACHED_THREADS is the number of threads to use when processing incoming requests. By default, memcached is configured to use 4 concurrent threads. The threading improves the performance of storing and retrieving data in the cache, using a locking system to prevent different threads overwriting or updating the same values. |
@@ -418,6 +421,7 @@ Kubernetes: `^1.19.0-0`
 | memcached-frontend.&ZeroWidthSpace;metrics.&ZeroWidthSpace;serviceMonitor.&ZeroWidthSpace;enabled | bool | `false` |  |
 | memcached-frontend.&ZeroWidthSpace;replicaCount | int | `2` |  |
 | memcached-frontend.&ZeroWidthSpace;resources | object | `{}` |  |
+| memcached-frontend.&ZeroWidthSpace;service.&ZeroWidthSpace;clusterIP | string | `"None"` |  |
 | nginx.&ZeroWidthSpace;affinity | object | `{}` |  |
 | nginx.&ZeroWidthSpace;annotations | object | `{}` |  |
 | nginx.&ZeroWidthSpace;autoscaling.&ZeroWidthSpace;behavior | object | `{}` | Ref: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#support-for-configurable-scaling-behavior |

--- a/values.yaml
+++ b/values.yaml
@@ -1578,7 +1578,9 @@ compactor:
 
 memcached-frontend:
   # -- Enables support for caching queries in the frontend
-  enabled: false
+  enabled: true
+  service:
+    clusterIP: None
   architecture: "high-availability"
   replicaCount: 2
   resources: {}
@@ -1601,7 +1603,9 @@ memcached-frontend:
 
 memcached-blocks-index:
   # -- Enables support for block index caching
-  enabled: false
+  enabled: true
+  service:
+    clusterIP: None
   architecture: "high-availability"
   replicaCount: 2
   resources: {}
@@ -1624,7 +1628,9 @@ memcached-blocks-index:
 
 memcached-blocks:
   # -- Enables support for block caching
-  enabled: false
+  enabled: true
+  service:
+    clusterIP: None
   architecture: "high-availability"
   replicaCount: 2
   resources: {}
@@ -1647,7 +1653,9 @@ memcached-blocks:
 
 memcached-blocks-metadata:
   # -- Enables support for block metadata caching
-  enabled: false
+  enabled: true
+  service:
+    clusterIP: None
   architecture: "high-availability"
   replicaCount: 2
   resources: {}


### PR DESCRIPTION
**What this PR does**: Switches to clusterIP none so that all instances can be discovered.


**Which issue(s) this PR fixes**:
Fixes #550

**Checklist**
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`, `[DEPENDENCY]`
