### PR TITLE
Speed up ci testing by skipping startupProbe in store-gateway

### DIFF
--- a/ci/test-configmap-values.yaml
+++ b/ci/test-configmap-values.yaml
@@ -137,6 +137,7 @@ ruler:
     - name: tmp-test
       mountPath: /tmp-test
 store_gateway:
+  startupProbe: null
   replicas: 1
   extraVolumes:
     - name: tmp-test

--- a/ci/test-deployment-values.yaml
+++ b/ci/test-deployment-values.yaml
@@ -144,6 +144,7 @@ ruler:
     - name: tmp-test
       mountPath: /tmp-test
 store_gateway:
+  startupProbe: null
   replicas: 1
   extraVolumes:
     - name: tmp-test

--- a/ci/test-sts-values.yaml
+++ b/ci/test-sts-values.yaml
@@ -135,6 +135,7 @@ ruler:
     - name: tmp-test
       mountPath: /tmp-test
 store_gateway:
+  startupProbe: null
   replicas: 1
   extraVolumes:
     - name: tmp-test


### PR DESCRIPTION
Speed up ci testing by skipping startupProbe in store-gateway

<img width="1299" height="393" alt="Screenshot 2025-09-19 at 6 50 16 AM" src="https://github.com/user-attachments/assets/5cae7ec9-3351-4566-bff2-43cf65a07ec8" />
