### PR TITLE
ci: support updating release PRs

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -57,7 +57,7 @@ jobs:
           git checkout -b release-${{ steps.version.outputs.new_version }}
           git add Chart.yaml README.md CHANGELOG.md docs/
           git commit -s -m "Release ${{ steps.version.outputs.new_version }}"
-          git push origin release-${{ steps.version.outputs.new_version }}
+          git push --force origin release-${{ steps.version.outputs.new_version }}
           gh pr create --title "Release ${{ steps.version.outputs.new_version }}" \
             --body "Automated release PR for version ${{ steps.version.outputs.new_version }}" \
             --base ${{ github.ref_name }} \


### PR DESCRIPTION
**What this PR does**:
This allows the `Release Chart` workflow to update its PRs via force push.

Fixes this error: https://github.com/cortexproject/cortex-helm-chart/actions/runs/22193778826/job/64188572790#step:9:21

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`, `[DEPENDENCY]`
