### PR TITLE
ci: update the release PR after every merge to master

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,6 +1,9 @@
 name: Release Chart
 
 on:
+  push:
+    branches:
+      - master
   workflow_dispatch:
     inputs:
       version:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,6 +20,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          token: ${{ secrets.CORTEX_HELM_CHART_CI_TOKEN }}
 
       - name: Configure Git
         run: |
@@ -52,7 +53,7 @@ jobs:
 
       - name: Create or Update Pull Request
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.CORTEX_HELM_CHART_CI_TOKEN }}
         run: |
           git checkout -b release-${{ steps.version.outputs.new_version }}
           git add Chart.yaml README.md CHANGELOG.md docs/


### PR DESCRIPTION
**What this PR does**:
* The release PR will now be triggered to update automatically after every merge to master
* Uses bot token in release workflow to bypass loop detection so PR checks run automatically (no workaround of closing and reopening the PR required)

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`, `[DEPENDENCY]`
