### PR TITLE
fix(volumeClaimTemplates): add apiVersion and kind to volumeClaimTemplates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## master / unreleased
 
-* [BUGFIX] Add `apiVersion` and `kind` fields to `volumeClaimTemplates` in StatefulSets to prevent ArgoCD sync flapping #<PR_NUMBER>
+* [BUGFIX] Add `apiVersion` and `kind` fields to `volumeClaimTemplates` in StatefulSets to prevent ArgoCD sync flapping #608
 
 ## 3.2.0 / 2026-02-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master / unreleased
 
+* [BUGFIX] Add `apiVersion` and `kind` fields to `volumeClaimTemplates` in StatefulSets to prevent ArgoCD sync flapping #<PR_NUMBER>
+
 ## 3.2.0 / 2026-02-26
 
 * [ENHANCEMENT] enable readiness probe on kiwigrid/k8s-sidecar #597

--- a/templates/alertmanager/alertmanager-statefulset.yaml
+++ b/templates/alertmanager/alertmanager-statefulset.yaml
@@ -28,7 +28,9 @@ spec:
   {{- end }}
   {{- end }}
   volumeClaimTemplates:
-    - metadata:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
         name: storage
         {{- if .Values.alertmanager.persistentVolume.annotations }}
         annotations:

--- a/templates/compactor/compactor-statefulset.yaml
+++ b/templates/compactor/compactor-statefulset.yaml
@@ -25,7 +25,9 @@ spec:
   {{- end }}
   {{- end }}
   volumeClaimTemplates:
-    - metadata:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
         name: storage
         {{- if .Values.compactor.persistentVolume.annotations }}
         annotations:

--- a/templates/ingester/ingester-statefulset.yaml
+++ b/templates/ingester/ingester-statefulset.yaml
@@ -28,7 +28,9 @@ spec:
   {{- end }}
   {{- end }}
   volumeClaimTemplates:
-    - metadata:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
         name: storage
         {{- if .Values.ingester.persistentVolume.annotations }}
         annotations:

--- a/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/templates/store-gateway/store-gateway-statefulset.yaml
@@ -28,7 +28,9 @@ spec:
   {{- end }}
   {{- end }}
   volumeClaimTemplates:
-    - metadata:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
         name: storage
         {{- if .Values.store_gateway.persistentVolume.annotations }}
         annotations:


### PR DESCRIPTION
Add apiVersion and kind to volumeClaimTemplates

**What this PR does**:

Adds explicit `apiVersion: v1` and `kind: PersistentVolumeClaim` fields to `volumeClaimTemplates` in all StatefulSet templates (alertmanager, compactor, ingester, store-gateway).

While these fields are optional in Kubernetes API, Kubernetes automatically populates them when creating StatefulSets. This caused ArgoCD to constantly detect drift between the desired state (without these fields) and the actual cluster state (with these fields), resulting in continuous sync flapping.

**Which issue(s) this PR fixes**:
Fixes #608

**Checklist**
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`, `[DEPENDENCY]`