### PR TITLE
fix: use correct podAnnotations reference in purger deployment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## master / unreleased
 
-* [BUGFIX] Purger: use correct podAnnotations reference instead of query_frontend's
+* [BUGFIX] Purger: use correct podAnnotations reference instead of query_frontend's #613
 
 ## 3.2.0 / 2026-02-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master / unreleased
 
+* [BUGFIX] Purger: use correct podAnnotations reference instead of query_frontend's
+
 ## 3.2.0 / 2026-02-26
 
 * [ENHANCEMENT] enable readiness probe on kiwigrid/k8s-sidecar #597

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master / unreleased
 
+* [BUGFIX] Purger: use correct podAnnotations reference instead of query_frontend's #613
+
 ## 3.3.5 / 2026-07-09
 
 * [BUGFIX] Querier: avoid rendering empty `env:` key when no env vars are set

--- a/templates/purger/purger-dep.yaml
+++ b/templates/purger/purger-dep.yaml
@@ -24,7 +24,7 @@ spec:
         {{- end }}
       annotations:
         checksum/config: {{ include "cortex.configChecksum" . }}
-      {{- with .Values.query_frontend.podAnnotations }}
+      {{- with .Values.purger.podAnnotations }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:


### PR DESCRIPTION
**What this PR does**:

The purger deployment template references `.Values.query_frontend.podAnnotations` instead of `.Values.purger.podAnnotations`, so any pod annotations configured for the purger component are never applied.

**Which issue(s) this PR fixes**:

N/A — found by code review.

**Checklist**
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`, `[DEPENDENCY]`