### PR TITLE
ci: when updating readme, use original author

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -27,10 +27,11 @@ jobs:
           if git diff --quiet -- README.md; then
             echo "updated=false" >> "$GITHUB_OUTPUT"
           else
-            git config user.name "github-actions[bot]"
-            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git config user.name "$(git log -1 --format='%an')"
+            git config user.email "$(git log -1 --format='%ae')"
             git add README.md
-            git commit -m "Auto-update README.md"
+            git commit -s -m "Auto-update README.md" \
+              -m "Co-authored-by: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>"
             git push
             echo "updated=true" >> "$GITHUB_OUTPUT"
           fi


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
3. Please do not edit/bump the Chart.yaml "version" field
-->

**What this PR does**:
When Github Actions updates the README on a Renovate PR, Renovate detects the new author and no longer updates the PR. Example: https://github.com/cortexproject/cortex-helm-chart/pull/612#issuecomment-4246805041

> Edited/Blocked Notification
> Renovate will not automatically rebase this PR, because it does not recognize the last commit author and assumes somebody else may have edited the PR.
> 
> You can manually request rebase by checking the rebase/retry box above.
> 
> ⚠️ Warning: custom changes will be lost.
> 

This PR reuses the original author metadata so that Renovate ignores the commit and will happily rebase the PR. It also adds a co-authored-by line so that it's easy to distinguish as a Github Actions commit.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`, `[DEPENDENCY]`
