### PR TITLE
Add parquet labels cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master / unreleased
 
+* [FEATURE] Add a parquet labels cache. #621
+
 ## 3.2.1 / 2026-04-20
 
 * [BUGFIX] Don't configure alertmanager in ruler if alertmanager is disabled #618

--- a/Chart.lock
+++ b/Chart.lock
@@ -11,5 +11,8 @@ dependencies:
 - name: memcached
   repository: https://charts.bitnami.com/bitnami
   version: 6.14.0
-digest: sha256:53271a70f0777e768309ece8663bc07002374ec7873b8dfb0b212d2813a4d12f
-generated: "2025-04-17T16:15:50.77219916Z"
+- name: memcached
+  repository: https://charts.bitnami.com/bitnami
+  version: 6.14.0
+digest: sha256:af0c109667e9402918877431f9e269c447c030d398c8e1ade6f7a0171a856c8f
+generated: "2026-04-21T11:51:34.160601+09:00"

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -36,3 +36,8 @@ dependencies:
     version: 6.14.0
     repository: https://charts.bitnami.com/bitnami
     condition: memcached-blocks-metadata.enabled
+  - name: memcached
+    alias: memcached-parquet-labels
+    version: 6.14.0
+    repository: https://charts.bitnami.com/bitnami
+    condition: memcached-parquet-labels.enabled

--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Kubernetes: `^1.19.0-0`
 | https://charts.bitnami.com/bitnami | memcached-blocks-index(memcached) | 6.14.0 |
 | https://charts.bitnami.com/bitnami | memcached-blocks(memcached) | 6.14.0 |
 | https://charts.bitnami.com/bitnami | memcached-blocks-metadata(memcached) | 6.14.0 |
+| https://charts.bitnami.com/bitnami | memcached-parquet-labels(memcached) | 6.14.0 |
 
 ## Values
 
@@ -446,6 +447,20 @@ Kubernetes: `^1.19.0-0`
 | memcached-frontend.&ZeroWidthSpace;replicaCount | int | `2` |  |
 | memcached-frontend.&ZeroWidthSpace;resources | object | `{}` |  |
 | memcached-frontend.&ZeroWidthSpace;service.&ZeroWidthSpace;clusterIP | string | `"None"` |  |
+| memcached-parquet-labels.&ZeroWidthSpace;architecture | string | `"high-availability"` |  |
+| memcached-parquet-labels.&ZeroWidthSpace;args | list | `["-m 1024"]` | Command line argument supplied to memcached |
+| memcached-parquet-labels.&ZeroWidthSpace;args[0] | string | `"-m 1024"` | The amount of memory allocated to memcached for object storage |
+| memcached-parquet-labels.&ZeroWidthSpace;disableValidation | bool | `false` | Bypass validation of the memcached configuration in case a custom image is in use |
+| memcached-parquet-labels.&ZeroWidthSpace;enabled | bool | `false` | Enables support for parquet labels caching |
+| memcached-parquet-labels.&ZeroWidthSpace;image.&ZeroWidthSpace;repository | string | `"memcached"` |  |
+| memcached-parquet-labels.&ZeroWidthSpace;image.&ZeroWidthSpace;tag | string | `"1.6.41"` |  |
+| memcached-parquet-labels.&ZeroWidthSpace;metrics.&ZeroWidthSpace;enabled | bool | `true` |  |
+| memcached-parquet-labels.&ZeroWidthSpace;metrics.&ZeroWidthSpace;image.&ZeroWidthSpace;repository | string | `"prom/memcached-exporter"` |  |
+| memcached-parquet-labels.&ZeroWidthSpace;metrics.&ZeroWidthSpace;image.&ZeroWidthSpace;tag | string | `"v0.16.0"` |  |
+| memcached-parquet-labels.&ZeroWidthSpace;metrics.&ZeroWidthSpace;serviceMonitor.&ZeroWidthSpace;enabled | bool | `false` |  |
+| memcached-parquet-labels.&ZeroWidthSpace;replicaCount | int | `2` |  |
+| memcached-parquet-labels.&ZeroWidthSpace;resources | object | `{}` |  |
+| memcached-parquet-labels.&ZeroWidthSpace;service.&ZeroWidthSpace;clusterIP | string | `"None"` |  |
 | nginx.&ZeroWidthSpace;affinity | object | `{}` |  |
 | nginx.&ZeroWidthSpace;annotations | object | `{}` |  |
 | nginx.&ZeroWidthSpace;autoscaling.&ZeroWidthSpace;behavior | object | `{}` | Ref: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#support-for-configurable-scaling-behavior |

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -97,6 +97,10 @@ Create configuration parameters for memcached configuration
 - "-blocks-storage.bucket-store.metadata-cache.backend=memcached"
 - "-blocks-storage.bucket-store.metadata-cache.memcached.addresses=dns+{{ .Release.Name }}-memcached-blocks-metadata.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:11211"
 {{- end -}}
+{{- if index .Values "memcached-parquet-labels" "enabled" }}
+- "-blocks-storage.bucket-store.parquet-labels-cache.backend=memcached"
+- "-blocks-storage.bucket-store.parquet-labels-cache.memcached.addresses=dns+{{ .Release.Name }}-memcached-parquet-labels.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:11211"
+{{- end -}}
 {{- end -}}
 
 {{/*

--- a/values.yaml
+++ b/values.yaml
@@ -1793,6 +1793,31 @@ memcached-blocks-metadata:
     serviceMonitor:
       enabled: false
 
+memcached-parquet-labels:
+  # -- Enables support for parquet labels caching
+  enabled: false
+  service:
+    clusterIP: None
+  architecture: "high-availability"
+  replicaCount: 2
+  resources: {}
+  # -- Bypass validation of the memcached configuration in case a custom image is in use
+  disableValidation: false
+  # -- Command line argument supplied to memcached
+  args:
+    # -- The amount of memory allocated to memcached for object storage
+    - -m 1024
+  image:
+    repository: memcached
+    tag: "1.6.41"
+  metrics:
+    enabled: true
+    image:
+      repository: prom/memcached-exporter
+      tag: "v0.16.0"
+    serviceMonitor:
+      enabled: false
+
 memberlist:
   service:
     annotations: {}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
3. Please do not edit/bump the Chart.yaml "version" field
-->

This PR adds a Parquet labels cache (memcached) so that users can configure the labels cache via the chart.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`, `[DEPENDENCY]`
