### PR TITLE
ci: fix bump version to minor upon FEATURE change

### DIFF
--- a/tools/bump-version.sh
+++ b/tools/bump-version.sh
@@ -19,6 +19,9 @@ else
     elif echo "$unreleased_changes" | grep -q "\[ENHANCEMENT\]"; then
         echo "Found [ENHANCEMENT], applying minor bump."
         bump="minor"
+    elif echo "$unreleased_changes" | grep -q "\[FEATURE\]"; then
+        echo "Found [FEATURE], applying minor bump."
+        bump="minor"
     else
         echo "Defaulting to patch bump ([BUGFIX], [DEPENDENCY], or other)."
         bump="patch"


### PR DESCRIPTION
This fixes bump-version.sh to detect `FEATURE` in CHANGELOG and bump the minor version. Previously it was only bumping minor version for `ENHANCEMENT`, causing #620 to compute the wrong target version.

### Problem logs:
https://github.com/cortexproject/cortex-helm-chart/actions/runs/25010065553/job/73243163179#step:5:12
```
Current version: 3.2.1
Unreleased changes analysis:

* [FEATURE] Add a parquet labels cache. #621
* [DEPENDENCY] update quay.io/cortexproject/cortex docker tag to v1.21.0 #622
* [DEPENDENCY] update kiwigrid/k8s-sidecar docker tag to v2.7.1 #623
Defaulting to patch bump ([BUGFIX], [DEPENDENCY], or other).
New version: 3.2.2
```

### Demo of fix:
https://github.com/cortexproject/cortex-helm-chart/actions/runs/25010593811/job/73245008093
```
Current version: 3.2.1
Unreleased changes analysis:
* [FEATURE] Add a parquet labels cache. #621
* [DEPENDENCY] update quay.io/cortexproject/cortex docker tag to v1.21.0 #622
* [DEPENDENCY] update kiwigrid/k8s-sidecar docker tag to v2.7.1 #623
Found [FEATURE], applying minor bump.
New version: 3.3.0
```