### PR TITLE
fix: use sidecar's containerSecurityContext condition in ruler sidecar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master / unreleased
 
+* [BUGFIX] Ruler: fix sidecar securityContext using main container's condition instead of sidecar's
+
 ## 3.3.4 / 2026-06-23
 
 * [DEPENDENCY] update kiwigrid/k8s-sidecar docker tag to v2.8.0 #646

--- a/templates/ruler/ruler-dep.yaml
+++ b/templates/ruler/ruler-dep.yaml
@@ -108,7 +108,7 @@ spec:
           {{- end }}
           resources:
             {{- toYaml .Values.ruler.sidecar.resources | nindent 12 }}
-          {{- if .Values.ruler.containerSecurityContext.enabled }}
+          {{- if .Values.ruler.sidecar.containerSecurityContext.enabled }}
           securityContext: {{- omit .Values.ruler.sidecar.containerSecurityContext "enabled" | toYaml | nindent 12 }}
           {{- end }}
           volumeMounts:


### PR DESCRIPTION
**What this PR does**:

The ruler sidecar container's securityContext condition checks `.Values.ruler.containerSecurityContext.enabled` (the main container's flag) instead of `.Values.ruler.sidecar.containerSecurityContext.enabled`. This means the sidecar's securityContext is controlled by the main container's toggle rather than its own. The alertmanager sidecar already uses the correct path.

**Which issue(s) this PR fixes**:

N/A

**Checklist**
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`, `[DEPENDENCY]`