### PR TITLE
fix: avoid rendering empty env key in querier deployment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master / unreleased
 
+* [BUGFIX] Querier: avoid rendering empty `env:` key when no env vars are set
+
 ## 3.3.4 / 2026-06-23
 
 * [DEPENDENCY] update kiwigrid/k8s-sidecar docker tag to v2.8.0 #646

--- a/templates/querier/querier-dep.yaml
+++ b/templates/querier/querier-dep.yaml
@@ -88,10 +88,10 @@ spec:
           {{- if .Values.querier.containerSecurityContext.enabled }}
           securityContext: {{- omit .Values.querier.containerSecurityContext "enabled" | toYaml | nindent 12 }}
           {{- end }}
+          {{- if .Values.querier.env }}
           env:
-            {{- if .Values.querier.env }}
-              {{- toYaml .Values.querier.env | nindent 12 }}
-            {{- end }}
+            {{- toYaml .Values.querier.env | nindent 12 }}
+          {{- end }}
           {{- with .Values.querier.lifecycle }}
           lifecycle:
             {{- toYaml . | nindent 12 }}


### PR DESCRIPTION
**What this PR does**:

The querier deployment renders an empty `env:` key when no environment variables are configured. Wrapped in conditional to match existig pattern.

**Checklist**
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`, `[DEPENDENCY]`