### PR TITLE
Add remote-write OTLP endpoint in nginx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## master / unreleased
 
+* [FEATURE] Add remote-write OTLP endpoint in nginx #667
 * [DEPENDENCY] update kiwigrid/k8s-sidecar docker tag to v2.11.2 #663
 
 ## 3.3.8 / 2026-08-17

--- a/templates/nginx/nginx-config.yaml
+++ b/templates/nginx/nginx-config.yaml
@@ -97,6 +97,11 @@ data:
         location = /api/v1/push {
           proxy_pass      {{ $push_endpoint }}$request_uri;
         }
+
+        ## OTLP metrics API
+        location = /api/v1/otlp/v1/metrics {
+          proxy_pass      {{ $push_endpoint }}$request_uri;
+        }
         {{- end }}
 
         {{- if .Values.alertmanager.enabled }}
@@ -161,6 +166,11 @@ data:
         location = /api/v1/push/{{ $org }} {
           proxy_set_header      X-Scope-OrgID {{ $org }};
           proxy_pass      {{ $.Values.nginx.config.upstream_protocol }}://{{ template "cortex.fullname" $ }}-distributor.{{ $rootDomain }}/api/v1/push;
+        }
+
+        location = /api/v1/otlp/v1/metrics/{{ $org }} {
+          proxy_set_header      X-Scope-OrgID {{ $org }};
+          proxy_pass      {{ $.Values.nginx.config.upstream_protocol }}://{{ template "cortex.fullname" $ }}-distributor.{{ $rootDomain }}/api/v1/otlp/v1/metrics;
         }
         {{- end }}
         {{- end }}


### PR DESCRIPTION
Information is from https://cortexmetrics.io/docs/api/#remote-write
I couldn't find the CONTRIBUTING.md guide

**What this PR does**:
It adds the missing otlp endpoint in the nginx configuration

**Which issue(s) this PR fixes**:
No issue opened, should I?

**Checklist**
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`, `[DEPENDENCY]`
